### PR TITLE
Adding macros to define enums with a name

### DIFF
--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -138,10 +138,11 @@
       (keyword? v) (ft/map->KeywordType (merge opts {:values values :open? open?}))
       (string? v)  (ft/map->StringType  (merge opts {:values values :open? open?})))))
 
-(defn eq [value & {:keys [description reference comment usage]}]
+(defn eq [value & {:keys [description reference comment usage name]}]
   (enum #{value}
         :open? false
         :default value
+        :name name
         :description description
         :reference reference
         :comment comment
@@ -193,3 +194,12 @@
      (map-of (merge ~opts
                     {:name ~(core/str name)})
              ~map-entries)))
+
+(defmacro def-enum-type [name values & opts]
+  `(def ~name
+     (enum ~values :name ~(core/str name) ~@opts)))
+
+(defmacro def-eq [name value & opts]
+  `(def ~name
+     (eq ~value :name ~(core/str name) ~@opts)))
+

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -49,6 +49,7 @@
   MapEntry
   (->schema' [{:keys [key type required?] :as entry} f]
     (assert (some? type) (format "Type nil for MapEntry with key %s" key))
+    (assert (some? key) (format "Key nil for MapEntry with type %s" type))
     [((if (not required?)
         s/optional-key
         identity)

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -48,6 +48,7 @@
 
   MapEntry
   (->schema' [{:keys [key type required?] :as entry} f]
+    (assert (some? type) (format "Type nil for MapEntry with key %s" key))
     [((if (not required?)
         s/optional-key
         identity)


### PR DESCRIPTION
To define an enum with a name, the code looks like this:
```clojure
(def NodeType 
 (f/enum #{"Indicator" "Judgement"} 
  :description "description" 
  :name "NodeType")
```

With the `def-enum-type` macro, the code become:
```clojure
(def-enum-type NodeType
  #{"Indicator" "Judgement"} 
  :description "description")
```

Idem for `eq` and `def-eq`.