### PR TITLE
don't optionalize Keyword map entries with no :values

### DIFF
--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -1,4 +1,5 @@
 (ns flanders.schema
+  (:refer-clojure :exclude [type key])
   (:require #?(:clj  [clojure.core.match :refer [match]]
                :cljs [cljs.core.match :refer-macros [match]])
             [clojure.zip :as z]
@@ -50,7 +51,8 @@
   (->schema' [{:keys [key type required?] :as entry} f]
     (assert (some? type) (str "Type nil for MapEntry with key " key))
     (assert (some? key) (str "Key nil for MapEntry with type " type))
-    [((if (not required?)
+    [((if (and (not required?)
+               (:values key))
         s/optional-key
         identity)
       (f (assoc key

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -52,7 +52,8 @@
     (assert (some? type) (str "Type nil for MapEntry with key " key))
     (assert (some? key) (str "Key nil for MapEntry with type " type))
     [((if (and (not required?)
-               (:values key))
+               (not (:open? key))
+               (seq (:values key)))
         s/optional-key
         identity)
       (f (assoc key

--- a/test/flanders/examples.clj
+++ b/test/flanders/examples.clj
@@ -12,3 +12,12 @@
    (f/entry :yes? f/any-bool))
   (f/optional-entries
    (f/entry :spam (f/eq :eggs))))
+
+(f/def-entity-type OptionalKeywordMapEntryExample
+  {:description "Foo"}
+  [(f/entry :foo f/any-str :required? false)
+   (f/entry
+    :relation_info
+    (f/map
+     [(f/entry f/any-keyword f/any :required? false)])
+    :required? true)])

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -1,9 +1,13 @@
 (ns flanders.schema-test
   (:require [clojure.test :refer [deftest is]]
-            [flanders.examples :refer [Example]]
+            [flanders.examples
+             :refer [Example
+                     OptionalKeywordMapEntryExample]]
             [flanders.core :as f]
+            [flanders.utils :refer [optionalize-all]]
             [flanders.schema :as fs]
-            [schema.core :as s]))
+            [schema.core :as s
+             :refer [Keyword Any]]))
 
 (deftest test-valid-schema
   (is
@@ -15,3 +19,10 @@
            :set #{1 3}}
      :yes? true
      :spam :eggs})))
+
+(deftest test-optional-kw-map-entry
+  (let [expected-schema
+        {#schema.core.OptionalKey{:k :foo} java.lang.String
+         :relation_info {Keyword Any}}]
+    (is (= expected-schema
+           (fs/->schema OptionalKeywordMapEntryExample)))))


### PR DESCRIPTION
closes #20

When converting flanders schemas to plumatic schemas, don't let Keyword entries optional if they don't have `:values`