### PR TITLE
fix anythingType making nil specs

### DIFF
--- a/src/flanders/spec.clj
+++ b/src/flanders/spec.clj
@@ -110,11 +110,9 @@
   ;; Leaves
 
   AnythingType
-  (->spec' [{:keys [gen spec]} _ _]
-    (with-gen
-      (or spec
-          any?)
-      gen))
+  (->spec' [{:keys [spec] :as node} _ _]
+    (with-gen node
+      (or spec any?)))
 
   BooleanType
   (->spec' [{:keys [open? spec default] :as node} _ _]


### PR DESCRIPTION
closes #22

This change aligns `AnythingType `with the other types, and stops spec from outputting exceptions while validating entities where `conditional`s are replaced with `any`.