### PR TITLE
Fix spec names conflicts for nested seq or set

### DIFF
--- a/src/flanders/spec.clj
+++ b/src/flanders/spec.clj
@@ -98,13 +98,13 @@
   SequenceOfType
   (->spec' [{:keys [type]} ns f]
     (let [result-kw (keyword ns "seq-of")]
-      (eval `(s/def ~result-kw ~(f type ns)))
+      (eval `(s/def ~result-kw ~(f type (str ns "." "seq-of"))))
       (eval `(s/coll-of ~result-kw))))
 
   SetOfType
   (->spec' [{:keys [type]} ns f]
     (let [result-kw (keyword ns "set-of")]
-      (eval `(s/def ~result-kw ~(f type ns)))
+      (eval `(s/def ~result-kw ~(f type (str ns "." "set-of"))))
       (eval `(s/coll-of ~result-kw :kind set?))))
 
   ;; Leaves

--- a/test/flanders/spec_test.clj
+++ b/test/flanders/spec_test.clj
@@ -104,3 +104,11 @@
                          (= 1 (count m))))
                 "test-map-4")
      {:spam "eggs"})))
+
+(deftest test-seq-set
+  (is (s/valid?
+       (fs/->spec (f/seq-of (f/seq-of f/any)) "test-seq")
+       [["foo"]]))
+  (is (s/valid?
+       (fs/->spec (f/set-of (f/set-of f/any-str)) "test-set")
+       #{#{"foo"}})))


### PR DESCRIPTION
Nested `seq-of` or `set-of` in flanders generates spec names conflicts. This PR fixes this issue by adding a suffix.