### PR TITLE
Add either operator

### DIFF
--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -63,19 +63,21 @@
           {:type t})))
 
 (defn either
-  {:arglists '([choices* & {:as [opts]}])}
-  [& args]
-  (let [[choices options] (split-with (complement keyword?) args)]
-    (assert (seq choices) "either expects at least one choice")
-    ;; else
-    (ft/map->EitherType
-     (into {:choices choices}
-           (keep
-            (fn [[k v]]
-              (if (keyword? k)
-                (if (not (= k :choices))
-                  [k v])))
-            (partition-all 2 options))))))
+  "Build an EitherType with the keyword arguments `opts`.
+
+    (either :choices [(int) (str)])
+    ;; =>
+    #flanders.types.EitherType{:choices [,,,]}
+
+  This function requires the value of the `:choices` key be a sequence
+  of at least length 1.
+
+    (either :choices [(int) (str)])
+    ;; =>
+    AssertionError Assert failed: either expects at least one choice"
+  [& {:keys [choices] :as opts}]
+  (assert (seq choices) "either expects at least one choice")
+  (ft/map->EitherType opts))
 
 (defn conditional [& pred+types]
   (assert (even? (count pred+types)) "pred and types must be even")

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -62,6 +62,21 @@
    (merge opts
           {:type t})))
 
+(defn either
+  {:arglists '([choices* & {:as [opts]}])}
+  [& args]
+  (let [[choices options] (split-with (complement keyword?) args)]
+    (assert (seq choices) "either expects at least one choice")
+    ;; else
+    (ft/map->EitherType
+     (into {:choices choices}
+           (keep
+            (fn [[k v]]
+              (if (keyword? k)
+                (if (not (= k :choices))
+                  [k v])))
+            (partition-all 2 options))))))
+
 (defn conditional [& pred+types]
   (assert (even? (count pred+types)) "pred and types must be even")
   (assert (seq pred+types) "must provide pred and types")

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -1,0 +1,9 @@
+(ns flanders.core-test
+  (:require [clojure.test :refer [deftest is]]
+            [flanders.core :as f])
+  (:import (flanders.types EitherType)))
+
+(deftest either-test
+  (is (instance? EitherType (f/either :choices [(f/int)])))
+  (is (thrown? java.lang.AssertionError (f/either)))
+  (is (thrown? java.lang.AssertionError (f/either :choices []))))


### PR DESCRIPTION
This patch provides a convenience function for constructing `flanders.types.EitherType`s.