### PR TITLE
Add type-script namespace

### DIFF
--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -83,6 +83,14 @@
   (-type-script-primitive-type-name [this]
     "boolean"))
 
+(extend-type flanders.types.KeywordType
+  TypeScriptFieldNames
+  (-type-script-field-names [this]
+    (map
+     (fn [value]
+       (type-script-munge (name value)))
+     (get this :values))))
+
 (extend-type flanders.types.IntegerType
   TypeScriptPrimitiveTypeName
   (-type-script-primitive-type-name [this]
@@ -152,19 +160,6 @@
   (-type-script-primitive-type-name [this]
     "number"))
 
-(extend-type flanders.types.StringType
-  TypeScriptPrimitiveTypeName
-  (-type-script-primitive-type-name [this]
-    "string"))
-
-(extend-type flanders.types.KeywordType
-  TypeScriptFieldNames
-  (-type-script-field-names [this]
-    (map
-     (fn [value]
-       (type-script-munge (name value)))
-     (get this :values))))
-
 (extend-type flanders.types.SetOfType
   TypeScriptPrimitiveTypeName
   (-type-script-primitive-type-name [this]
@@ -182,6 +177,11 @@
                (type-script-primitive-type-name sequence-type)
                "any")
            "[]"))))
+
+(extend-type flanders.types.StringType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "string"))
 
 ;; ---------------------------------------------------------------------
 ;; Type graph

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -165,6 +165,15 @@
        (type-script-munge (name value)))
      (get this :values))))
 
+(extend-type flanders.types.SetOfType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    (let [sequence-type (get this :type)]
+      (str (or (type-script-type-name sequence-type)
+               (type-script-primitive-type-name sequence-type)
+               "any")
+           "[]"))))
+
 (extend-type flanders.types.SequenceOfType
   TypeScriptPrimitiveTypeName
   (-type-script-primitive-type-name [this]

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -30,14 +30,6 @@
   [x]
   (instance? flanders.types.EitherType x))
 
-(defn type-script-sequence-type [x]
-  (let [ts-type (type-script-type x)]
-    (if (string? ts-type)
-      (if (union? x)
-        (str "(" ts-type ")[]")
-        (str ts-type "[]"))
-      "any[]")))
-
 (defprotocol TypeScriptInterfaceDeclaration
   (-type-script-interface-declaration [this]))
 
@@ -94,6 +86,17 @@
   (or (type-script-interface-declaration x)
       (type-alias-declaration x)
       (type-enum-declaration x)))
+
+(defn type-script-sequence-type [x]
+  (let [ts-name (type-script-type-name x)]
+    (if (string? ts-name)
+      (str ts-name "[]")
+      (let [ts-type (type-script-type x)]
+        (if (string? ts-type)
+          (if (union? x)
+            (str "(" ts-type ")[]")
+            (str ts-type "[]"))
+          "any[]")))))
 
 ;; ---------------------------------------------------------------------
 ;; Protocol implementation
@@ -154,8 +157,8 @@
     (if-some [signatures (seq (type-script-property-signatures this))]
       (let [type-body (string/replace (string/join ";\n" (sort signatures))
                                       #"(?m:^)"
-                                      "\n  ")]
-        (format "{%s\n}" type-body))
+                                      "  ")]
+        (format "{\n%s\n}" type-body))
       "{}"))
   
   TypeScriptInterfaceDeclaration

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -18,9 +18,9 @@
      as a single key haveing a value type of
     `flanders.types.EitherType`.
 
-  * `:warn-on-duplicate-names` causes a warning to be printed for
-    each group of `flanders.types.<X>Type`s which have the `:name`
-    name."
+  * `:warn-on-duplicate-names` when rendering multiple type
+    declarations, causes a warning to be printed for each group of
+    Flanders typess which have the same `:name`."
   #{:warn-on-duplicate-entries
     :warn-on-duplicate-names})
 
@@ -45,7 +45,7 @@
     "any"))
 
 (defn type-script-union
-  "Render `xs`"
+  "Render `xs` as a TypeScript UnionType or \"any\"."
   [xs]
   {:pre [(sequential? xs)]}
   (let [types (map type-script-type xs)]

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -67,8 +67,7 @@
   [x]
   (if (satisfies? TypeScript x)
     (-type-script x)
-    (or (type-script-type-alias x)
-        (type-script-interface x))))
+    (type-script-type-alias x)))
 
 ;; ---------------------------------------------------------------------
 ;; Protocol implementation

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -31,12 +31,23 @@
 (defprotocol TypeScriptType
   (-type-script-type [this]))
 
-(defn type-script-type [x]
+(defn type-script-type
+  "Render `x` as a TypeScript type e.g. one of
+
+    * UnionOrIntersectionOrPrimaryType,
+    * FunctionType, or
+    * ConstructorType
+
+  as defined in the TypeScript grammer."
+  [x]
   (if (satisfies? TypeScriptType x)
     (-type-script-type x)
     "any"))
 
-(defn type-script-union [xs]
+(defn type-script-union
+  "Render `xs`"
+  [xs]
+  {:pre [(sequential? xs)]}
   (let [types (map type-script-type xs)]
     (if (some #{nil "any"} types)
       "any"

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -263,7 +263,7 @@
         (recur new-graph new-queue))
       graph)))
 
-(defn type-script-of-seqable
+(defn type-script-of-sequential
   {:private true}
   [schemas]
   (let [graph (reduce into-graph empty-graph schemas)
@@ -284,7 +284,12 @@
                            ranked-nodes)]
     (string/join "\n" type-script-lines)))
 
-(extend-type clojure.lang.Seqable
+(extend-type clojure.lang.ISeq
   TypeScript
   (-type-script [this]
-    (type-script-of-seqable this)))
+    (type-script-of-sequential this)))
+
+(extend-type clojure.lang.IPersistentVector
+  TypeScript
+  (-type-script [this]
+    (type-script-of-sequential this)))

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -1,0 +1,274 @@
+(ns flanders.type-script
+  (:require [clojure.string :as string]
+            [flanders.types]))
+
+;; ---------------------------------------------------------------------
+;; Protocols
+
+(defprotocol TypeScript
+  (-type-script [this]))
+
+(defprotocol TypeScriptEnum
+  (-type-script-enum [this]))
+
+(defprotocol TypeScriptFieldNames
+  (-type-script-field-names [this]))
+
+(defprotocol TypeScriptFields
+  (-type-script-fields [this]))
+
+(defprotocol TypeScriptTypeName
+  (-type-script-type-name [this]))
+
+(defprotocol TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]))
+
+(defn type-script-munge
+  [s]
+  (clojure.string/replace s #"[^A-Za-z0-9]+" "_"))
+
+(defn type-script-primitive-type-name
+  "Return the primitive TypeScript type name of `x`. Returns `nil` if `x`
+  does not have a primitive type."
+  [x]
+  (if (satisfies? TypeScriptPrimitiveTypeName x)
+    (-type-script-primitive-type-name x)))
+
+(defn type-script-type-name
+  "Attempt to return the TypeScript type name of `x`. Returns `nil` if
+  the type name cannot be determined."
+  [x]
+  (let [x-name (if (satisfies? TypeScriptTypeName x)
+                 (-type-script-type-name x)
+                 (get x :name))]
+    (if (string? x-name)
+      (type-script-munge x-name))))
+
+(defn type-script-type-alias
+  {:private true}
+  [x]
+  (if-some [type-name (type-script-type-name x)]
+    (if-some [primitive-name (type-script-primitive-type-name x)]
+      (format "type %s = %s;" type-name primitive-name))))
+
+(defn type-script-field-names
+  [x]
+  (if (satisfies? TypeScriptFieldNames x)
+    (-type-script-field-names x)))
+
+(defn type-script-fields
+  [x]
+  (if (satisfies? TypeScriptFields x)
+    (-type-script-fields x)))
+
+(defn type-script
+  "Attempts to convert `x` into a `string?` of TypeScript
+  code. Returns `nil` if `x` cannot be converted."
+  [x]
+  (if (satisfies? TypeScript x)
+    (-type-script x)
+    (or (type-script-type-alias x)
+        (type-script-interface x))))
+
+;; ---------------------------------------------------------------------
+;; Protocol implementation
+
+(extend-type flanders.types.AnythingType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "any"))
+
+(extend-type flanders.types.BooleanType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "boolean"))
+
+(extend-type flanders.types.IntegerType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "number"))
+
+(extend-type flanders.types.InstType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "Date | string"))
+
+(extend-type flanders.types.MapEntry
+  TypeScriptFields
+  (-type-script-fields [this]
+    (let [? (if (get this :required?) "" "?")
+          entry-type (get this :type)
+          field-type-name (or (type-script-type-name entry-type)
+                              (type-script-primitive-type-name entry-type)
+                              "any")]
+      (map
+       (fn [field-name]
+         (format "%s%s: %s;" field-name ? field-type-name))
+       (type-script-field-names (get this :key))))))
+
+(extend-type flanders.types.MapType
+  TypeScript
+  (-type-script [this]
+    (if-some [type-name (type-script-type-name this)]
+      (let [type-fields (type-script-fields this)]
+        (format "interface %s {\n%s\n}"
+                type-name
+                (string/replace (string/join "\n" (sort type-fields))
+                                #"(?m:^)"
+                                "  ")))))
+
+  TypeScriptFields
+  (-type-script-fields [this]
+    (let [;; Because it is possible to construct a MapType with
+          ;; duplicate keys and type script does not allow interfaces
+          ;; to contain duplicate fields, we need a strategy for
+          ;; electing keys whenever duplicates exist. Here we do a
+          ;; simple thing which is to pick either the first
+          ;; non-required duplicate key or the first key.
+          entries (reduce
+                   (fn [entries [k duplicate-entries]]
+                     (when (< 1 (count duplicate-entries))
+                       (println "WARNING:" (type-script-type-name this)
+                                "contains duplicate definitions for the field(s)"
+                                (string/join ", " (map pr-str (type-script-field-names k)))))
+                     (conj entries
+                           (or (some (fn [entry]
+                                       (if-not (get entry :required?)
+                                         entry))
+                                     duplicate-entries)
+                               (first duplicate-entries))))
+                   []
+                   (group-by :key (get this :entries)))]
+      (mapcat type-script-fields entries)))
+
+  TypeScriptTypeName
+  (-type-script-type-name [this]
+    (let [this-name (get this :name)]
+      (if (string? this-name)
+        (str "I" this-name)))))
+
+(extend-type flanders.types.NumberType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "number"))
+
+(extend-type flanders.types.StringType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    "string"))
+
+(extend-type flanders.types.KeywordType
+  TypeScriptFieldNames
+  (-type-script-field-names [this]
+    (map
+     (fn [value]
+       (type-script-munge (name value)))
+     (get this :values))))
+
+(extend-type flanders.types.SequenceOfType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    (let [sequence-type (get this :type)]
+      (str (or (type-script-type-name sequence-type)
+               (type-script-primitive-type-name sequence-type)
+               "any")
+           "[]"))))
+
+;; ---------------------------------------------------------------------
+;; Type graph
+
+(def ^{:private true}
+  empty-graph
+  {:from-to {}
+   :to-from {}})
+
+(defn initialize-from-to
+  {:private true}
+  [graph node]
+  (update-in graph [:from-to node] (fnil identity #{})))
+
+(defn initialize-to-from
+  {:private true}
+  [graph node]
+  (update-in graph [:to-from node] (fnil identity #{})))
+
+(defn add-node
+  {:private true}
+  [graph node]
+  (-> graph
+      (initialize-to-from node)
+      (initialize-from-to node)))
+
+(defn add-from-to
+  {:private true}
+  [graph from-node to-node]
+  (let [old-to-nodes (get (get graph :from-to) from-node)
+        new-to-nodes (if (set? old-to-nodes)
+                       (conj old-to-nodes to-node)
+                       #{to-node})]
+    (assoc-in graph [:from-to from-node] new-to-nodes)))
+
+(defn add-to-from
+  {:private true}
+  [graph to-node from-node]
+  (let [old-from-nodes (get (get graph :to-from) to-node)
+        new-from-nodes (if (set? old-from-nodes)
+                         (conj old-from-nodes from-node)
+                         #{from-node})]
+    (assoc-in graph [:to-from to-node] new-from-nodes)))
+
+(defn add-edge
+  {:private true}
+  [graph from-node to-node]
+  (add-to-from (add-from-to graph
+                            from-node
+                            to-node)
+               to-node
+               from-node))
+
+(defn add-edges
+  {:private true}
+  [graph from-node to-nodes]
+  (reduce
+   (fn [new-graph to-node]
+     (add-edge new-graph from-node to-node))
+   (add-node graph from-node)
+   to-nodes))
+
+(defn into-graph
+  {:private true}
+  [graph root]
+  (loop [graph graph
+         queue (conj clojure.lang.PersistentQueue/EMPTY root)]
+    (if-some [node (peek queue)]
+      (let [node-children (flanders.protocols/node-children node)
+            new-graph (add-edges graph node node-children)
+            new-queue (into (pop queue) node-children)]
+        (recur new-graph new-queue))
+      graph)))
+
+(defn type-script-of-seqable
+  {:private true}
+  [schemas]
+  (let [graph (reduce into-graph empty-graph schemas)
+        from-to (get graph :from-to)
+        named-nodes (filter type-script-type-name (keys from-to))
+        ranked-nodes (sort-by
+                      (fn [node]
+                        (count (get from-to node)))
+                      named-nodes)
+        type-script-lines (sequence
+                           (comp (mapcat
+                                  (fn [node]
+                                    (if-some [ts (type-script node)]
+                                      (if-some [description (get node :description)]
+                                        [(string/replace description #"(?m:^)" "// ") ts]
+                                        [ts]))))
+                                 (distinct))
+                           ranked-nodes)]
+    (string/join "\n" type-script-lines)))
+
+(extend-type clojure.lang.Seqable
+  TypeScript
+  (-type-script [this]
+    (type-script-of-seqable this)))

--- a/src/flanders/type_script.clj
+++ b/src/flanders/type_script.clj
@@ -83,6 +83,14 @@
   (-type-script-primitive-type-name [this]
     "boolean"))
 
+(extend-type flanders.types.EitherType
+  TypeScriptPrimitiveTypeName
+  (-type-script-primitive-type-name [this]
+    (let [choice-names (map type-script-type-name (get this :choices))]
+      (if (some #{nil "any"} choice-names)
+        "any"
+        (string/join " | " (sort (distinct choice-names)))))))
+
 (extend-type flanders.types.KeywordType
   TypeScriptFieldNames
   (-type-script-field-names [this]

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -103,6 +103,9 @@
 (deftest seq-of-test
   (is (= "number[]"
          (f.ts/type-script-type (f/seq-of (f/int)))))
+
+  (is (= "ID[]"
+         (f.ts/type-script-type (f/seq-of (f/int :name "ID")))))
   
   (is (= "(number | string)[]"
          (f.ts/type-script-type (f/seq-of (f/either :choices [(f/int) (f/str)])))))
@@ -122,6 +125,9 @@
 (deftest set-of-test
   (is (= "number[]"
          (f.ts/type-script-type (f/set-of (f/int)))))
+
+  (is (= "ID[]"
+         (f.ts/type-script-type (f/set-of (f/int :name "ID")))))
   
   (is (= "(number | string)[]"
          (f.ts/type-script-type (f/set-of (f/either :choices [(f/int) (f/str)])))))

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -143,3 +143,14 @@
 
   (is (= "type T = number[];"
          (f.ts/type-script-declaration (f/set-of (f/int) :name "T")))))
+
+(let [TId (f/int :name "ID"
+                 :description "An ID")
+      TUser (f/map [(f/entry (f/key :name) (f/str))
+                    (f/entry (f/key :id) TId)]
+                   :name "User"
+                   :description "A User")
+      TUserList (f/seq-of TUser
+                          :name "User List"
+                          :description "A list of User")]
+  (f.ts/type-script-declarations [TId TUserList TUser]))

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -1,0 +1,94 @@
+(ns flanders.type-script-test
+  (:require [clojure.test :refer [deftest is]]
+            [flanders.core :as f]
+            [flanders.type-script :as f.ts]
+            [flanders.types :as f.t]))
+
+(deftest anything-type-test
+  (is (= "any" (f.ts/type-script-type (f/anything))))
+
+  (is (nil? (f.ts/type-script-declaration (f/anything))))
+
+  (is (= "type T = any;"
+         (f.ts/type-script-declaration (f/anything :name "T"))))
+
+  (is (nil? (f.ts/type-script-type-name (f/anything))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f/anything :name "T")))))
+
+(deftest boolean-type-test
+  (is (= "boolean" (f.ts/type-script-type (f/bool))))
+
+  (is (nil? (f.ts/type-script-declaration (f/bool))))
+
+  (is (= "type T = boolean;"
+         (f.ts/type-script-declaration (f/bool :name "T"))))
+
+  (is (nil? (f.ts/type-script-type-name (f/bool))))
+
+  (is (= "T" (f.ts/type-script-type-name (f/bool :name "T")))))
+
+(deftest integer-type-test
+  (is (nil? (f.ts/type-script-declaration (f/int))))
+
+  (is (= "type T = number;"
+         (f.ts/type-script-declaration (f/int :name "T"))))
+
+  (is (nil? (f.ts/type-script-type-name (f/int))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f/int :name "T")))))
+
+(deftest keyword-type-test
+  (is (= "string"
+         (f.ts/type-script-type (f/key :k))))
+
+  (is (nil? (f.ts/type-script-declaration (f/key :k))))
+
+  (is (= "type T = string;"
+         (f.ts/type-script-declaration (f/key :k :name "T"))))
+
+  (is (nil? (f.ts/type-script-type-name (f/key :k))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f/key :k :name "T")))))
+
+(deftest string-type-test
+  (is (= "string"
+         (f.ts/type-script-type (f/str))))
+
+  (is (nil? (f.ts/type-script-type-name (f/str))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f/str :name "T"))))
+
+  (is (nil? (f.ts/type-script-declaration (f/str))))
+
+  (is (= "type T = string;"
+         (f.ts/type-script-declaration (f/str :name "T")))))
+
+;; TODO: Replace `f.t/map->EitherType` with `f/either`.
+(deftest either-type-test
+  (is (= "number"
+         (f.ts/type-script-type (f.t/map->EitherType {:choices [(f/int)]}))))
+
+  (is (= "number | string"
+         (f.ts/type-script-type (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+
+  (is (nil? (f.ts/type-script-type-name (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f.t/map->EitherType {:choices [(f/int) (f/str)] :name "T"}))))
+
+  (is (nil? (f.ts/type-script-declaration (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+
+  (is (= "type T = number | string;"
+         (f.ts/type-script-declaration (f.t/map->EitherType {:choices [(f/int) (f/str)] :name "T"})))))
+
+(deftest map-type-test
+  (is (= "interface T {}"
+         (f.ts/type-script-declaration (f/map [] :name "T"))))
+
+  (is (= "interface T {\n  a: any\n}" (f.ts/type-script-declaration
+          (f/map [(f/entry (f/key :a) (f/anything))] :name "T")))))

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -99,3 +99,41 @@
 
   (is (= "interface T {\n  a: any\n}"
          (f.ts/type-script-declaration (f/map [(f/entry (f/key :a) (f/anything))] :name "T")))))
+
+(deftest seq-of-test
+  (is (= "number[]"
+         (f.ts/type-script-type (f/seq-of (f/int)))))
+  
+  (is (= "(number | string)[]"
+         (f.ts/type-script-type (f/seq-of (f/either :choices [(f/int) (f/str)])))))
+
+  (is (= "(number)[]"
+         (f.ts/type-script-type (f/seq-of (f/either :choices [(f/int)])))))
+
+  (is (nil? (f.ts/type-script-type-name (f/seq-of (f/int)))))
+
+  (is (= "T" (f.ts/type-script-type-name (f/seq-of (f/int) :name "T"))))
+
+  (is (nil? (f.ts/type-script-declaration (f/seq-of (f/int)))))
+
+  (is (= "type T = number[];"
+         (f.ts/type-script-declaration (f/seq-of (f/int) :name "T")))))
+
+(deftest set-of-test
+  (is (= "number[]"
+         (f.ts/type-script-type (f/set-of (f/int)))))
+  
+  (is (= "(number | string)[]"
+         (f.ts/type-script-type (f/set-of (f/either :choices [(f/int) (f/str)])))))
+
+  (is (= "(number)[]"
+         (f.ts/type-script-type (f/set-of (f/either :choices [(f/int)])))))
+
+  (is (nil? (f.ts/type-script-type-name (f/set-of (f/int)))))
+
+  (is (= "T" (f.ts/type-script-type-name (f/set-of (f/int) :name "T"))))
+
+  (is (nil? (f.ts/type-script-declaration (f/set-of (f/int)))))
+
+  (is (= "type T = number[];"
+         (f.ts/type-script-declaration (f/set-of (f/int) :name "T")))))

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -87,8 +87,16 @@
          (f.ts/type-script-declaration (f.t/map->EitherType {:choices [(f/int) (f/str)] :name "T"})))))
 
 (deftest map-type-test
+  (is (= "{\n  a: any\n}"
+         (f.ts/type-script-type (f/map [(f/entry (f/key :a) (f/anything))]))))
+
+  (is (nil? (f.ts/type-script-type-name (f/map [(f/entry (f/key :a) (f/anything))]))))
+
+  (is (= "T"
+         (f.ts/type-script-type-name (f/map [(f/entry (f/key :a) (f/anything))] :name "T"))))
+
   (is (= "interface T {}"
          (f.ts/type-script-declaration (f/map [] :name "T"))))
 
-  (is (= "interface T {\n  a: any\n}" (f.ts/type-script-declaration
-          (f/map [(f/entry (f/key :a) (f/anything))] :name "T")))))
+  (is (= "interface T {\n  a: any\n}"
+         (f.ts/type-script-declaration (f/map [(f/entry (f/key :a) (f/anything))] :name "T")))))

--- a/test/flanders/type_script_test.clj
+++ b/test/flanders/type_script_test.clj
@@ -68,23 +68,22 @@
   (is (= "type T = string;"
          (f.ts/type-script-declaration (f/str :name "T")))))
 
-;; TODO: Replace `f.t/map->EitherType` with `f/either`.
 (deftest either-type-test
   (is (= "number"
-         (f.ts/type-script-type (f.t/map->EitherType {:choices [(f/int)]}))))
+         (f.ts/type-script-type (f/either :choices [(f/int)]))))
 
   (is (= "number | string"
-         (f.ts/type-script-type (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+         (f.ts/type-script-type (f/either :choices [(f/int) (f/str)]))))
 
-  (is (nil? (f.ts/type-script-type-name (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+  (is (nil? (f.ts/type-script-type-name (f/either :choices [(f/int) (f/str)]))))
 
   (is (= "T"
-         (f.ts/type-script-type-name (f.t/map->EitherType {:choices [(f/int) (f/str)] :name "T"}))))
+         (f.ts/type-script-type-name (f/either :choices [(f/int) (f/str)] :name "T"))))
 
-  (is (nil? (f.ts/type-script-declaration (f.t/map->EitherType {:choices [(f/int) (f/str)]}))))
+  (is (nil? (f.ts/type-script-declaration (f/either :choices [(f/int) (f/str)]))))
 
   (is (= "type T = number | string;"
-         (f.ts/type-script-declaration (f.t/map->EitherType {:choices [(f/int) (f/str)] :name "T"})))))
+         (f.ts/type-script-declaration (f/either :choices [(f/int) (f/str)] :name "T")))))
 
 (deftest map-type-test
   (is (= "{\n  a: any\n}"


### PR DESCRIPTION
This patch adds functionality for compiling Flanders schemas to TypeScript type definitions.

### Basic usage

```clj
(require '[flanders.type-script :as f.ts])

;; Render a single declaration.
(f.ts/type-script-declaration flanders-schema)

;; Render a multiple of declarations.
(f.ts/type-script-declarations [schema-1 ,,, schema-n])
```

### Example

Here is an example of rendering a group of Flanders schemas as TypeScript.

```clj
(let [TId (f/int :name "ID"
                 :description "An ID")
      TUser (f/map [(f/entry (f/key :name) (f/str))
                    (f/entry (f/key :id) TId)]
                   :name "User"
                   :description "A User")
      TUserList (f/seq-of TUser
                          :name "User List"
                          :description "A list of User")]
  (f.ts/type-script-declarations [TId TUserList TUser]))
```

```ts
// An ID
type ID = number;
// A list of User
type User_List = User[];
// A User
interface User {
  id: ID;
  name: string
}
```

The `type-script-declarations` function takes sequence of Flanders schemas and inserts each one and its children recursively into a directed graph. Then, it emits each `:name`d node in the graph as a TypeScript declaration ordered by the number of references it has from most to least. Though TypeScript does not care about which order declarations appear in, this ordering can be helpful to a human as it tends to float the most primitive declarations to the top.