### PR TITLE
Relax def-entity-type fspec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.18-SNAPSHOT"
+(defproject threatgrid/flanders "0.1.18"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.18"
+(defproject threatgrid/flanders "0.1.19-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.19-SNAPSHOT"
+(defproject threatgrid/flanders "0.1.19"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.19"
+(defproject threatgrid/flanders "0.1.19-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -201,19 +201,24 @@
 
 (defmacro def-entity-type
   [name description & map-entries]
-  (assert (or (string? description) (map? description)))
-  `(def ~name
-     (map-of (if (map? ~description)
-               (merge ~description
-                      {:name ~(core/str name)})
-               {:description ~description
-                :name ~(core/str name)})
-             ~@map-entries)))
+  `(let [description# ~description
+         options# (cond
+                    (map? description#)
+                    (merge description# {:name ~(core/str name)})
+
+                    (string? description#)
+                    {:description description#
+                     :name ~(core/str name)}
+
+                    :else
+                    (throw (ex-info "def-entity-type description argument must be a `map?` or a `string?`"
+                                    {:description description#})))]
+     (def ~name
+       (map-of options# ~@map-entries))))
 
 (spec/fdef def-entity-type
   :args (spec/cat :name simple-symbol?
-                  :description (spec/or :string-description string?
-                                        :map-description map?)
+                  :description any?
                   :map-entries (spec/* any?)))
 
 (defmacro def-map-type [name map-entries & {:as opts}]

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -25,8 +25,17 @@
 
   (is (= "Description"
          (get (deref (f/def-entity-type Bar {:description "Description"}))
-              :description))))
+              :description)))
 
+  (is (= "Description"
+         (let [description "Description"]
+           (get (deref (f/def-entity-type Bar description))
+                :description))))
+
+  (is (= "Description"
+         (let [okay {:description "Description"}]
+           (get (deref (f/def-entity-type Bar description))
+                :description)))))
 
 (deftest either-test
   (is (instance? EitherType (f/either :choices [(f/int)])))

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -1,7 +1,32 @@
 (ns flanders.core-test
   (:require [clojure.test :refer [deftest is]]
             [flanders.core :as f])
-  (:import (flanders.types EitherType)))
+  (:import (flanders.types EitherType
+                           MapType)))
+
+
+(deftest def-entity-type-test
+  (is (thrown? clojure.lang.ExceptionInfo
+               (f/def-entity-type Foo 'bad)))
+
+  (is (thrown? clojure.lang.ExceptionInfo
+               (let [bad 43]
+                 (f/def-entity-type Foo 43))))
+
+  (is (instance? clojure.lang.Var
+                 (f/def-entity-type Bar "")))
+
+  (is (instance? MapType
+                 (deref (f/def-entity-type Bar ""))))
+
+  (is (= "Description"
+         (get (deref (f/def-entity-type Bar "Description"))
+              :description)))
+
+  (is (= "Description"
+         (get (deref (f/def-entity-type Bar {:description "Description"}))
+              :description))))
+
 
 (deftest either-test
   (is (instance? EitherType (f/either :choices [(f/int)])))

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -33,7 +33,7 @@
                 :description))))
 
   (is (= "Description"
-         (let [okay {:description "Description"}]
+         (let [description {:description "Description"}]
            (get (deref (f/def-entity-type Bar description))
                 :description)))))
 

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -11,7 +11,7 @@
 
   (is (thrown? clojure.lang.ExceptionInfo
                (let [bad 43]
-                 (f/def-entity-type Foo 43))))
+                 (f/def-entity-type Foo bad))))
 
   (is (instance? clojure.lang.Var
                  (f/def-entity-type Bar "")))


### PR DESCRIPTION
This patch relaxes the `fspec` for the `description` parameter of `def-entity-type`. Restricting the syntax to either `string?` or `map?` broke some CTIM schema definitions. Given the examples that broke [[1](https://github.com/threatgrid/ctim/pull/257)][[2]( https://github.com/threatgrid/ctim/issues/256)] it seems like the expectation is for `description` to be an expression that is evaluated and verified at runtime rather than compile time. If this is the expectation then this patch provides that behavior.