### PR TITLE
Add signature type

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.18-SNAPSHOT"
+(defproject threatgrid/flanders "0.1.18"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.18"
+(defproject threatgrid/flanders "0.1.19-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -96,6 +96,26 @@
     (ft/map->EitherType {:choices types
                          :tests tests})))
 
+(defn signature
+  "Build a SignatureType with the keyword arguments `opts`.
+
+    (signature :parameters [(int) (str)]
+               :return (str))
+    ;; =>
+    #flanders.types.SignatureType{:parameters [,,,]
+                                  :return #flanders.types.StringType{,,,}}
+  "
+  [& {:keys [parameters return] :as opts}]
+  (if (some? parameters)
+    (assert (sequential? parameters) ":parameters argument must be `sequential?`"))
+  (let [return (if (some? return)
+                 return
+                 (anything))
+        parameter-list (ft/map->ParameterListType {:parameters (vec parameters)})]
+    (ft/map->SignatureType
+     (merge opts {:parameters parameter-list
+                  :return return}))))
+
 ;; ----------------------------------------------------------------------
 ;; Defining Leaf Nodes
 ;; ----------------------------------------------------------------------

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -104,7 +104,12 @@
     ;; =>
     #flanders.types.SignatureType{:parameters [,,,]
                                   :return #flanders.types.StringType{,,,}}
-  "
+
+  If the `:return` option is not specified the return type of the
+  signature is will be specified as `flanders.types.AnythingType`.
+
+  A signature can be variadic by specifying the `:rest-parameter`
+  argument."
   [& {:keys [parameters rest-parameter return] :as opts}]
   (if (some? parameters)
     (assert (sequential? parameters) ":parameters argument must be `sequential?`"))

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -96,11 +96,11 @@
     (ft/map->EitherType {:choices types
                          :tests tests})))
 
-(defn signature
+(defn sig
   "Build a SignatureType with the keyword arguments `opts`.
 
-    (signature :parameters [(int) (str)]
-               :return (str))
+    (sig :parameters [(int) (str)]
+         :return (str))
     ;; =>
     #flanders.types.SignatureType{:parameters [,,,]
                                   :return #flanders.types.StringType{,,,}}

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -105,15 +105,17 @@
     #flanders.types.SignatureType{:parameters [,,,]
                                   :return #flanders.types.StringType{,,,}}
   "
-  [& {:keys [parameters return] :as opts}]
+  [& {:keys [parameters rest-parameter return] :as opts}]
   (if (some? parameters)
     (assert (sequential? parameters) ":parameters argument must be `sequential?`"))
   (let [return (if (some? return)
                  return
                  (ft/map->AnythingType {}))
-        parameter-list (ft/map->ParameterListType {:parameters (vec parameters)})]
+        parameter-list (ft/map->ParameterListType
+                        {:parameters (vec parameters)})]
     (ft/map->SignatureType
      (merge opts {:parameters parameter-list
+                  :rest-parameter rest-parameter
                   :return return}))))
 
 ;; ----------------------------------------------------------------------

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -110,7 +110,7 @@
     (assert (sequential? parameters) ":parameters argument must be `sequential?`"))
   (let [return (if (some? return)
                  return
-                 (anything))
+                 (ft/map->AnythingType {}))
         parameter-list (ft/map->ParameterListType {:parameters (vec parameters)})]
     (ft/map->SignatureType
      (merge opts {:parameters parameter-list

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -4,13 +4,16 @@
             #?(:clj  [flanders.types :as ft]
                :cljs [flanders.types
                       :as ft
-                      :refer [AnythingType BooleanType EitherType InstType
-                              IntegerType KeywordType MapEntry MapType
-                              NumberType SequenceOfType SetOfType StringType]]))
+                      :refer [AnythingType BooleanType EitherType
+                              InstType IntegerType KeywordType
+                              MapEntry MapType NumberType
+                              SequenceOfType SetOfType SignatureType
+                              StringType]]))
   #?(:clj (:import [flanders.types
-                    AnythingType BooleanType EitherType InstType IntegerType
-                    KeywordType MapEntry MapType NumberType SequenceOfType
-                    SetOfType StringType]
+                    AnythingType BooleanType EitherType InstType
+                    IntegerType KeywordType MapEntry MapType
+                    NumberType SequenceOfType SetOfType SignatureType
+                    StringType]
                    [java.util Date])))
 
 (defprotocol JsonExampleNode
@@ -77,7 +80,11 @@
 
   StringType
   (->example [_ _]
-    "string"))
+    "string")
+
+  SignatureType
+  (->example [_ _]
+    (constantly "anything")))
 
 ;; This is a fast implementation of making an example, but it could be better
 ;; - It could take advantage of generators (to be non-deterministic)

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -263,10 +263,11 @@
   (->markdown-part [this loc]
     (->short-description this))
 
+  ;; (Integer, String ...) => Integer
   (->short-description [this]
     (let [parameter-list-str (->short-description (get this :parameters))
           rest-parameter-str (if-some [rest-parameter (get this :rest-parameter)]
-                               (str (->short-description rest-parameter) "...")
+                               (str (->short-description rest-parameter) " ...")
                                "")
           return-str (->short-description (get this :return))]
        (case [(str/blank? parameter-list-str) (str/blank? rest-parameter-str)]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -10,12 +10,15 @@
                :cljs [flanders.types
                       :refer [AnythingType BooleanType EitherType InstType
                               IntegerType KeywordType MapEntry MapType
-                              NumberType SequenceOfType SetOfType StringType]])
+                              ParameterListType NumberType
+                              SequenceOfType SetOfType SignatureType
+                              StringType]])
             [flanders.utils :as fu])
   #?(:clj (:import [flanders.types
-                    AnythingType BooleanType EitherType InstType IntegerType
-                    KeywordType MapEntry MapType NumberType SequenceOfType
-                    SetOfType StringType])))
+                    AnythingType BooleanType EitherType InstType
+                    IntegerType KeywordType MapEntry MapType
+                    NumberType ParameterListType SequenceOfType
+                    SetOfType SignatureType StringType])))
 
 (defprotocol MarkdownNode
   (->markdown-part [node depth])
@@ -249,6 +252,35 @@
     nil)
   (->short-description [this]
     (str "#{" (->short-description (:type this)) "}"))
+
+  ParameterListType
+  (->markdown-part [this loc]
+    nil)
+  (->short-description [this]
+    (str/join ", " (map ->short-description (get this :parameters))))
+
+  SignatureType
+  (->markdown-part [this loc]
+    (->short-description this))
+
+  (->short-description [this]
+    (let [parameter-list-str (->short-description (get this :parameters))
+          rest-parameter-str (if-some [rest-parameter (get this :rest-parameter)]
+                               (str (->short-description rest-parameter) "...")
+                               "")
+          return-str (->short-description (get this :return))]
+       (case [(str/blank? parameter-list-str) (str/blank? rest-parameter-str)]
+         [true true]
+         (str "() => " return-str)
+
+         [true false]
+         (str "(" rest-parameter-str ") => " return-str)
+
+         [false true]
+         (str "(" parameter-list-str ") => " return-str)
+
+         [false false]
+         (str "(" parameter-list-str ", " rest-parameter-str ") => " return-str))))
 
   EitherType
   (->markdown-part [this loc]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -263,7 +263,6 @@
   (->markdown-part [this loc]
     (->short-description this))
 
-  ;; (Integer, String ...) => Integer
   (->short-description [this]
     (let [parameter-list-str (->short-description (get this :parameters))
           rest-parameter-str (if-some [rest-parameter (get this :rest-parameter)]

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -6,18 +6,21 @@
             [flanders.predicates :as fp]
             #?(:clj  [flanders.types]
                :cljs [flanders.types
-                      :refer [AnythingType BooleanType EitherType InstType
-                              IntegerType KeywordType MapEntry MapType
-                              NumberType SequenceOfType SetOfType StringType]])
+                      :refer [AnythingType BooleanType EitherType
+                              InstType IntegerType KeywordType
+                              MapEntry MapType NumberType
+                              ParameterListType SequenceOfType
+                              SetOfType SignatureType StringType]])
             [flanders.protocols :as prots]
             [flanders.utils :as fu]
             #?(:clj [ring.swagger.json-schema :as rs])
             [schema.core :as s]
             [schema-tools.core :as st])
   #?(:clj (:import [flanders.types
-                    AnythingType BooleanType EitherType InstType IntegerType
-                    KeywordType MapEntry MapType NumberType SequenceOfType
-                    SetOfType StringType])))
+                    AnythingType BooleanType EitherType InstType
+                    IntegerType KeywordType MapEntry MapType
+                    NumberType ParameterListType SequenceOfType
+                    SetOfType SignatureType StringType])))
 
 (defprotocol SchemaNode
   (->schema' [node f]))
@@ -70,6 +73,10 @@
              (map f entries))
      description))
 
+  ParameterListType
+  (->schema' [{:keys [parameters]} f]
+    (mapv f parameters))
+
   SequenceOfType
   (->schema' [{:keys [type]} f]
     [(f type)])
@@ -77,6 +84,14 @@
   SetOfType
   (->schema' [{:keys [type]} f]
     #{(f type)})
+
+  SignatureType
+  (->schema' [{:keys [parameters rest-parameter return name]} f]
+    (let [parameters (f parameters)]
+      (s/make-fn-schema (f return)
+                        (if (some? rest-parameter)
+                          [(conj parameters [(f rest-parameter)])]
+                          [parameters]))))
 
   ;; Leaves
 

--- a/src/flanders/spec.clj
+++ b/src/flanders/spec.clj
@@ -108,10 +108,8 @@
       (eval `(s/coll-of ~result-kw :kind set?))))
 
   SignatureType
-  (->spec' [this ns f]
-    (let [parameter-list (get this :parameters)
-          parameters (get parameter-list :parameters)
-          rest-parameter (get this :rest-parameter)
+  (->spec' [{:keys [parameters rest-parameter return]} ns f]
+    (let [parameters (get parameters :parameters)
           parameter-count (count parameters)
           ;; Using gensym to produce a unique function name pending a
           ;; better approach.
@@ -129,7 +127,7 @@
                           parameters)
                        ~@(if (some? rest-parameter)
                            [:a* `(s/* ~(f rest-parameter (str ns ".a*")))]))
-          :ret ~(if-some [return (get this :return)]
+          :ret ~(if (some? return)
                   (f return (str ns ".return"))
                   `any?)))))
 

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -131,6 +131,12 @@
                           name :- (s/maybe s/Str)]
   TreeNode
   (branch? [_] true)
-  (node-children [_] parameters return)
-  (make-node [this [new-parameters new-return]]
-    (SignatureType. new-parameters new-return name)))
+  (node-children [_]
+    (if (some? rest-parameter)
+      [parameters return rest-parameter]
+      [parameters return]))
+  (make-node [this [new-parameters new-return new-rest-parameter]]
+    (SignatureType. new-parameters
+                    new-rest-parameter
+                    new-return
+                    name)))

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -117,3 +117,19 @@
                       reference :- (s/maybe s/Str)
                       comment :- (s/maybe s/Str)
                       usage :- (s/maybe s/Str)])
+
+(defrecord ParameterListType [parameters :- [(s/protocol TreeNode)]]
+  TreeNode
+  (branch? [_] true)
+  (node-children [_] parameters)
+  (make-node [this new-parameters]
+    (ParameterListType. (vec new-parameters))))
+
+(defrecord SignatureType [parameter-list :- ParameterListType
+                          return :- (s/protocol TreeNode)
+                          name :- (s/maybe s/Str)]
+  TreeNode
+  (branch? [_] true)
+  (node-children [_] parameter-list return)
+  (make-node [this [new-parameter-list new-return]]
+    (SignatureType. new-parameter-list new-return name)))

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -126,6 +126,7 @@
     (ParameterListType. (vec new-parameters))))
 
 (defrecord SignatureType [parameters :- ParameterListType
+                          rest-parameter :- (s/maybe (s/protocol TreeNode))
                           return :- (s/protocol TreeNode)
                           name :- (s/maybe s/Str)]
   TreeNode

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -125,11 +125,11 @@
   (make-node [this new-parameters]
     (ParameterListType. (vec new-parameters))))
 
-(defrecord SignatureType [parameter-list :- ParameterListType
+(defrecord SignatureType [parameters :- ParameterListType
                           return :- (s/protocol TreeNode)
                           name :- (s/maybe s/Str)]
   TreeNode
   (branch? [_] true)
-  (node-children [_] parameter-list return)
-  (make-node [this [new-parameter-list new-return]]
-    (SignatureType. new-parameter-list new-return name)))
+  (node-children [_] parameters return)
+  (make-node [this [new-parameters new-return]]
+    (SignatureType. new-parameters new-return name)))

--- a/src/flanders/types.cljc
+++ b/src/flanders/types.cljc
@@ -121,7 +121,7 @@
 (defrecord ParameterListType [parameters :- [(s/protocol TreeNode)]]
   TreeNode
   (branch? [_] true)
-  (node-children [_] parameters)
+  (node-children [_] (seq parameters))
   (make-node [this new-parameters]
     (ParameterListType. (vec new-parameters))))
 

--- a/test/flanders/core_test.clj
+++ b/test/flanders/core_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.test :refer [deftest is]]
             [flanders.core :as f])
   (:import (flanders.types EitherType
-                           MapType)))
-
+                           MapType
+                           SignatureType)))
 
 (deftest def-entity-type-test
   (is (thrown? clojure.lang.ExceptionInfo
@@ -41,3 +41,7 @@
   (is (instance? EitherType (f/either :choices [(f/int)])))
   (is (thrown? java.lang.AssertionError (f/either)))
   (is (thrown? java.lang.AssertionError (f/either :choices []))))
+
+(deftest sig-test
+  (is (instance? SignatureType (f/sig)))
+  (is (thrown? java.lang.AssertionError (f/sig :parameters 10))))

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -1,0 +1,24 @@
+(ns flanders.markdown-test
+  (:require [clojure.test :refer [deftest is]]
+            [flanders.core :as f]
+            [flanders.markdown :as f.markdown]))
+
+
+(deftest signuature-type->markdown
+  ;; TODO: This causes an error.
+  (is (= (f.markdown/->markdown (f/sig :parameters []))
+         "() => Anything\n\n"))
+
+  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]))
+         "(Integer) => Anything\n\n"))
+
+  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))
+         "(Integer,  String) => Anything\n\n\n"))
+
+  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
+                                       :rest-parameter (f/str)))
+         "(Integer,  String...) => Anything\n\n\n"))
+
+  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
+                                       :rest-parameter (f/str)))
+         "(Integer,  String...) => Anything\n\n\n")))

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -3,11 +3,9 @@
             [flanders.core :as f]
             [flanders.markdown :as f.markdown]))
 
-
 (deftest signuature-type->markdown
-  ;; TODO: This causes an error.
   (is (= (f.markdown/->markdown (f/sig :parameters []))
-         "() => Anything\n\n"))
+         "() => Anything\n"))
 
   (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]))
          "(Integer) => Anything\n\n"))
@@ -17,8 +15,8 @@
 
   (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
                                        :rest-parameter (f/str)))
-         "(Integer,  String...) => Anything\n\n\n"))
+         "(Integer,  String ...) => Anything\n\n\n"))
 
   (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
                                        :rest-parameter (f/str)))
-         "(Integer,  String...) => Anything\n\n\n")))
+         "(Integer,  String ...) => Anything\n\n\n")))

--- a/test/flanders/spec_test.clj
+++ b/test/flanders/spec_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.core.match :refer [match]]
             [flanders.core :as f]
             [flanders.examples :refer [Example]]
             [flanders.spec :as fs]
@@ -112,3 +113,20 @@
   (is (s/valid?
        (fs/->spec (f/set-of (f/set-of f/any-str)) "test-set")
        #{#{"foo"}})))
+
+(deftest sig-spec-test
+  (let [spec-key (fs/->spec (f/sig :parameters [(f/int)]) "foo")]
+    (is (match (s/describe spec-key)
+          (['fspec :args (['cat :a0 _] :seq) :ret _ :fn nil] :seq)
+          true
+
+          _
+          false)))
+
+  (let [spec-key (fs/->spec (f/sig :parameters [(f/int)] :rest-parameter (f/int)) "foo")]
+    (is (match (s/describe spec-key)
+          (['fspec :args (['cat :a0 _ :a* (['* _] :seq)] :seq) :ret _ :fn nil] :seq)
+          true
+
+          _
+          false))))


### PR DESCRIPTION
This patch adds support for describing function signatures via the `sig` core helper. Signatures 

* map one parameter list to one return type.
* have optional support for variadic argument.

Here is an example of how one might specify an add function which describes a function like `+`.

```clj
;; () => int
(def add-0
  (sig :parameters [(int)]
       :return (int :equals 0)
       :name "Add Arity 0"))

;; (int) => int
(def add-1
  (sig :parameters [(int)]
       :return (int)
       :name "Add Arity 1"))

;; (int int & int) => int
(def add-2*
  (sig :parameters [(int) (int)]
       :rest-paremeter (int)
       :return (int)
       :name "Add Arity 2*"))

(def add
  (either :choices [add-0 add-1 add-2*]
          :name "Add"))
```

## TODO

- [x] Implement example.cljc generator
- [x] Implement markdown.cljc generator
- [x] Implement schema.cljc generator
- [x] Implement spec.cljc generator