### PR TITLE
Various Rendering tweaks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
 
-(defproject threatgrid/flanders "0.1.20-SNAPSHOT"
+(defproject threatgrid/flanders "0.1.21-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -83,8 +83,17 @@
     "string")
 
   SignatureType
-  (->example [_ _]
-    "function () {}"))
+  (->example [{:keys [parameters rest-parameter return]} f]
+    (let [arguments (mapv
+                     (fn [i parameter]
+                       [(str "arg" i) (f parameter)])
+                     (range)
+                     (:parameters parameters))
+          arguments (if (some? rest-parameter)
+                      (conj arguments ["argN"(f rest-parameter)])
+                      arguments)]
+      {:arguments (into {} arguments)
+       :returns (f return)})))
 
 ;; This is a fast implementation of making an example, but it could be better
 ;; - It could take advantage of generators (to be non-deterministic)

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -90,7 +90,7 @@
                      (range)
                      (:parameters parameters))
           arguments (if (some? rest-parameter)
-                      (conj arguments ["argN"(f rest-parameter)])
+                      (conj arguments ["argN" (f rest-parameter)])
                       arguments)]
       {:arguments (into {} arguments)
        :returns (f return)})))

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -84,7 +84,7 @@
 
   SignatureType
   (->example [_ _]
-    (constantly "anything")))
+    "function () {}"))
 
 ;; This is a fast implementation of making an example, but it could be better
 ;; - It could take advantage of generators (to be non-deterministic)


### PR DESCRIPTION
This improves a few things with TypeScript declaration rendering.

I also fixed a bug with the JSON example rendering of `SignatureType`; you can't turn a function into JSON. ~I changed the rending of that to `"function () {}"`, however, I'm open to input.~ Maybe it should be an error since, if your goal is to render JSON, it should not have function signatures in it.