### PR TITLE
Improve Markdown code for SignatureType

### DIFF
--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -265,15 +265,18 @@
                                (str (->short-description rest-parameter) " ...")
                                "")
           return-str (->short-description (get this :return))]
-      (str "# `" (get this :name) "`"
-           "\n\n"
+      (str (if-some [fn-name (get this :name)]
+             (str "# `" fn-name "`"
+                  "\n\n"))
            "### Signature"
            "\n\n"
            (->short-description this)
            "\n\n"
-           "### Description"
-           "\n\n"
-           (->description this))))
+           (let [description (->description this)]
+             (if (not (str/blank? description))
+               (str "### Description"
+                    "\n\n"
+                    description))))))
 
   (->short-description [this]
     (let [parameter-list-str (->short-description (get this :parameters))

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -237,8 +237,7 @@
            "* This entry's type is a set (allows zero or more distinct values)\n")
          (->comment this)
          (->usage this)
-         (->reference this)
-         ))
+         (->reference this)))
   (->short-description [_] "Property")
 
   SequenceOfType
@@ -261,7 +260,20 @@
 
   SignatureType
   (->markdown-part [this loc]
-    (->short-description this))
+    (let [parameter-list-str (get this :parameters)
+          rest-parameter-str (if-some [rest-parameter (get this :rest-parameter)]
+                               (str (->short-description rest-parameter) " ...")
+                               "")
+          return-str (->short-description (get this :return))]
+      (str "# `" (get this :name) "`"
+           "\n\n"
+           "### Signature"
+           "\n\n"
+           (->short-description this)
+           "\n\n"
+           "### Description"
+           "\n\n"
+           (->description this))))
 
   (->short-description [this]
     (let [parameter-list-str (->short-description (get this :parameters))
@@ -269,18 +281,18 @@
                                (str (->short-description rest-parameter) " ...")
                                "")
           return-str (->short-description (get this :return))]
-       (case [(str/blank? parameter-list-str) (str/blank? rest-parameter-str)]
-         [true true]
-         (str "() => " return-str)
+      (case [(str/blank? parameter-list-str) (str/blank? rest-parameter-str)]
+        [true true]
+        (str "() => " return-str)
 
-         [true false]
-         (str "(" rest-parameter-str ") => " return-str)
+        [true false]
+        (str "(" rest-parameter-str ") => " return-str)
 
-         [false true]
-         (str "(" parameter-list-str ") => " return-str)
+        [false true]
+        (str "(" parameter-list-str ") => " return-str)
 
-         [false false]
-         (str "(" parameter-list-str ", " rest-parameter-str ") => " return-str))))
+        [false false]
+        (str "(" parameter-list-str ", " rest-parameter-str ") => " return-str))))
 
   EitherType
   (->markdown-part [this loc]

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -4,19 +4,22 @@
             [flanders.markdown :as f.markdown]))
 
 (deftest signuature-type->markdown
-  (is (= (f.markdown/->markdown (f/sig :parameters []))
-         "() => Anything\n"))
+  (is (= "### Signature\n\n() => Anything\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters []))))
 
-  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]))
-         "(Integer) => Anything\n\n"))
+  (is (= "### Signature\n\n(Integer) => Anything\n\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters [(f/int)]))))
 
-  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))
-         "(Integer,  String) => Anything\n\n\n"))
+  (is (= "### Signature\n\n(Integer,  String) => Anything\n\n\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))))
 
-  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
-                                       :rest-parameter (f/str)))
-         "(Integer,  String ...) => Anything\n\n\n"))
+  (is (= "### Signature\n\n(Integer,  String ...) => Anything\n\n\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
 
-  (is (= (f.markdown/->markdown (f/sig :parameters [(f/int)]
-                                       :rest-parameter (f/str)))
-         "(Integer,  String ...) => Anything\n\n\n")))
+  (is (= "### Signature\n\n(Integer,  String ...) => Anything\n\n\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
+
+  (is (= "# `Foo`\n\n### Signature\n\n() => Anything\n\n### Description\n\nThe Foo.\n\n\n"
+         (f.markdown/->markdown (f/sig :name "Foo"
+                                       :description "The Foo."
+                                       :parameters [])))))


### PR DESCRIPTION
This patch improves `SignatureType` rendering a bit.

```md
# `function_name`

### Signature

(A, B) => C

### Description
```