### PR TITLE
Update deps, ensure JDK 11 compatibility, add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: clojure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: clojure
+lein: 2.9.1
+script: lein do clean, test
+
+cache:
+  directories:
+    - $HOME/bin
+    - $HOME/.m2
 
 jdk:
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: clojure
+
+jdk:
+  - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ cache:
     - $HOME/.m2
 
 jdk:
+  - openjdk8
   - openjdk11

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ validators, etc.
 
 ## License
 
-Copyright © 2016 Cisco Systems
+Copyright © 2016-2020 Cisco Systems
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,17 @@
-(def schema-tools-version "0.9.1")
-(def schema-version "1.1.7")
+(def schema-tools-version "0.12.1")
+(def schema-version "1.1.12")
 
 (defproject threatgrid/flanders "0.1.23-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/core.match "0.3.0-alpha5"
-                  :exclusions [org.clojure/tools.reader]]
-                 [cheshire "5.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.match "0.3.0"]
+                 [cheshire "5.9.0"]
 
                  [prismatic/schema ~schema-version]
-                 [metosin/ring-swagger "0.24.4"]
+                 [metosin/ring-swagger "0.26.2"]
                  [metosin/schema-tools ~schema-tools-version]]
   :profiles {:dev
-             {:dependencies [[org.clojure/test.check "0.9.0"]]}})
+             {:dependencies [[org.clojure/test.check "0.10.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -10,5 +10,6 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/ring-swagger "0.26.2"]
                  [metosin/schema-tools "0.12.2"]]
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "0.10.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def schema-tools-version "0.12.1")
+(def schema-tools-version "0.12.2")
 (def schema-version "1.1.12")
 
 (defproject threatgrid/flanders "0.1.23-SNAPSHOT"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,3 @@
-(def schema-tools-version "0.12.2")
-(def schema-version "1.1.12")
-
 (defproject threatgrid/flanders "0.1.23-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
@@ -10,8 +7,8 @@
                  [org.clojure/core.match "0.3.0"]
                  [cheshire "5.9.0"]
 
-                 [prismatic/schema ~schema-version]
+                 [prismatic/schema "1.1.12"]
                  [metosin/ring-swagger "0.26.2"]
-                 [metosin/schema-tools ~schema-tools-version]]
+                 [metosin/schema-tools "0.12.2"]]
   :profiles {:dev
              {:dependencies [[org.clojure/test.check "0.10.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/core.match "0.3.0"]
                  [cheshire "5.9.0"]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -258,11 +258,11 @@
   (->markdown-part [this loc]
     nil)
   (->short-description [this]
-    (str/join "," (map (fn [schema]
-                         (str (if-some [name (get schema :name)]
-                                (str "*" name "* "))
-                              (->short-description schema)))
-                       (get this :parameters))))
+    (str/join ", " (map (fn [schema]
+                          (str (when-some [name (get schema :name)]
+                                 (str "*" name "* "))
+                               (->short-description schema)))
+                        (get this :parameters))))
 
   SignatureType
   (->markdown-part [{:keys [description parameters] :as this} loc]
@@ -353,7 +353,7 @@
          (->comment this :leaf)
          (->usage this :leaf)
          (->reference this :leaf)))
-  (->short-description [this] (str (:name this) " String"))
+  (->short-description [this] (str (:name this) "String"))
 
   InstType
   (->markdown-part [this loc]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -258,11 +258,11 @@
   (->markdown-part [this loc]
     nil)
   (->short-description [this]
-    (str/join ", " (map (fn [schema]
-                          (str (if-some [name (get schema :name)]
-                                 (str "*" name "* "))
-                               (->short-description schema)))
-                        (get this :parameters))))
+    (str/join "," (map (fn [schema]
+                         (str (if-some [name (get schema :name)]
+                                (str "*" name "* "))
+                              (->short-description schema)))
+                       (get this :parameters))))
 
   SignatureType
   (->markdown-part [{:keys [description parameters] :as this} loc]

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -3,23 +3,23 @@
             [flanders.core :as f]
             [flanders.markdown :as f.markdown]))
 
-(deftest signuature-type->markdown
+(deftest signature-type->markdown
   (is (= "### Signature\n\n() => Anything\n\n\n"
          (f.markdown/->markdown (f/sig :parameters []))))
 
   (is (= "### Signature\n\n(Integer) => Anything\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int)]))))
 
-  (is (= "### Signature\n\n(Integer,  String) => Anything\n\n\n\n\n"
+  (is (= "### Signature\n\n(Integer, String) => Anything\n\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))))
 
-  (is (= "### Signature\n\n(Integer,  String ...) => Anything\n\n\n\n\n"
+  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
 
-  (is (= "### Signature\n\n(Integer,  String ...) => Anything\n\n\n\n\n"
+  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
 
-  (is (= "# `Foo`\n\n### Signature\n\n() => Anything\n\n### Description\n\nThe Foo.\n\n\n"
+  (is (= "# `Foo`\n\n### Description\n\nThe Foo.\n\n### Signature\n\n() => Anything\n\n\n"
          (f.markdown/->markdown (f/sig :name "Foo"
                                        :description "The Foo."
                                        :parameters [])))))

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -13,6 +13,9 @@
   (is (= "### Signature\n\n(Integer, String) => Anything\n\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))))
 
+  (is (= "### Signature\n\n(Integer, String, Integer, String) => Anything\n\n\n\n\n\n\n"
+         (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str) (f/int) (f/str)]))))
+
   (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n\n\n\n"
          (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
 


### PR DESCRIPTION
Also fixes tests due to some markdown-related tests failing. Should be able to regenerate `iroh-engine` docs to get rid of superfluous spaces in `:name`'d String types.