### PR TITLE
Emit more concise, interlinked .md documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 lein: 2.9.1
-script: lein do clean, test
+script: lein with-profile -dev,+ci do clean, test
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ validators, etc.
 
 ## License
 
-Copyright © 2016-2020 Cisco Systems
+Copyright © 2016-2021 Cisco Systems
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/flanders "0.1.24-SNAPSHOT"
+(defproject threatgrid/flanders "1.0.0-alpha1"
   :description "flanders"
   :url "https://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,14 @@
 (defproject threatgrid/flanders "0.1.24-SNAPSHOT"
   :description "flanders"
-  :url "http://github.com/threatgrid/flanders"
+  :url "https://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.2"]
                  [org.clojure/core.match "1.0.0"]
                  [cheshire "5.9.0"]
-
                  [prismatic/schema "1.1.12"]
                  [metosin/ring-swagger "0.26.2"]
                  [metosin/schema-tools "0.12.2"]]
-  :global-vars {*warn-on-reflection* true}
-  :profiles {:dev
-             {:dependencies [[org.clojure/test.check "1.0.0"]]}})
+  :profiles {:test {:dependencies [[org.clojure/test.check "1.0.0"]]}
+             :ci {:pedantic? :abort
+                  :global-vars {*warn-on-reflection* true}}})

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -85,11 +85,17 @@
                      "` ∷ "
                      (->short-description type))))
 
+(defn children-of-composite-type? [loc]
+  (-> loc z/up z/node class #{EitherType}))
+
 (defn- ->leaf-header [this loc]
-  (let [type-str (->short-description this)]
+  (let [sep (if (children-of-composite-type? loc)
+              "  * "
+              "* ")
+        type-str (->short-description this)]
     (if (fp/key loc)
-      (str "* " type-str " Key\n")
-      (str "* " type-str " Value\n"))))
+      (str sep type-str " Key\n")
+      (str sep type-str "\n"))))
 
 (defn- ->schema-str [this loc]
   (let [schema (pr-str (fs/->schema-at-loc this loc))
@@ -234,12 +240,9 @@
 
   ReferenceNode
   (->markdown-part [{:keys [text anchor jump-anchor md-file-ref] :as this} loc]
-    (let [up-node (-> loc z/up z/node)]
-      ;; only render the node when it's not already indicated in the header:
-      (when (some (fn [x]
-                    (instance? x up-node))
-                  [EitherType])
-        (->leaf-header this loc))))
+    ;; only render the node when it's not already indicated in the header:
+    (when (children-of-composite-type? loc)
+      (->leaf-header this loc)))
   (->short-description [this]
     (maybe-link this))
 
@@ -323,7 +326,7 @@
          (->comment this)
          (->usage this :leaf)
          (->reference this :leaf)
-         "  * Only one of the following schemas will match\n"))
+         "* Only one of the following schemas will match:\n"))
   (->short-description [_] "Either")
 
   AnythingType

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -75,15 +75,15 @@
               ["\n\n"])))
 
 (defn- ->entry-header [{:keys [key type]} loc]
-  (->header loc
-            " Property "
-            (let [key-schema (fs/->schema-at-loc key
-                                                 (z/down loc))]
-              (if (keyword? key-schema)
-                (name key-schema)
-                (->short-description key)))
-            " ∷ "
-            (->short-description type)))
+  (str "#" (->header loc
+                     " `"
+                     (let [key-schema (fs/->schema-at-loc key
+                                                          (z/down loc))]
+                       (if (keyword? key-schema)
+                         (name key-schema)
+                         (->short-description key)))
+                     "` ∷ "
+                     (->short-description type))))
 
 (defn- ->leaf-header [this loc]
   (let [type-str (->short-description this)]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -229,7 +229,7 @@
          (->usage this)))
   (->short-description [{name :name}]
     (if (seq name)
-      (str "*" name "* Object")
+      (str "*" name "*")
       "Object"))
 
   ReferenceNode
@@ -373,7 +373,11 @@
          (->comment this :leaf)
          (->usage this :leaf)
          (->reference this :leaf)))
-  (->short-description [this] (str (:name this) "String"))
+  (->short-description [this]
+    (-> this
+        :name
+        (str "String")
+        (str/replace "StringString" "String")))
 
   InstType
   (->markdown-part [this loc]
@@ -381,7 +385,7 @@
          (->comment this :leaf)
          (->usage this :leaf)
          (->reference this :leaf)))
-  (->short-description [_] "Inst (Date)")
+  (->short-description [_] "DateTime")
 
   KeywordType
   (->markdown-part [this loc]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -222,11 +222,11 @@
          (if (nil? (z/up loc))
            (->header loc " " (->short-description this))
            (->leaf-header this loc))
+         (->reference this)
          (->description this)
          (->map-summary this loc)
          (->comment this)
-         (->usage this)
-         (->reference this)))
+         (->usage this)))
   (->short-description [{name :name}]
     (if (seq name)
       (str "*" name "* Object")

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -34,7 +34,7 @@
 
 (defn ->default [{:keys [default values]}]
   (when (and default (> (count values) 1))
-    (str "  * Default: " default "\n")))
+    (str "  * Default: `" (pr-str default) "`\n")))
 
 (defn ->description
   ([node]
@@ -62,7 +62,7 @@
 (defn ->equals [{:keys [values]} loc]
   (when (and (= 1 (count values))
              (not (fp/key loc)))
-    (str "  * Must equal: " (pr-str (first values)) "\n")))
+    (str "  * Must equal: `" (pr-str (first values)) "`\n")))
 
 (defn- ->header [loc & parts]
   (apply str (concat
@@ -103,10 +103,14 @@
 
 (defn- ->values [{v :values}]
   (when (and v (> (count v) 1))
-    (str "  * Allowed Values:\n"
-         (str/join
-           (->> (sort (seq v))
-                (map #(str "    * " % "\n")))))))
+    (->> v
+         seq
+         sort
+         (map #(str "    * `"
+                    (pr-str %)
+                    "`\n"))
+         str/join
+         (str "  * Allowed values:\n"))))
 
 (defn- ->comment
   ([node]

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -51,13 +51,16 @@
   ([node]
    (->reference node false))
   ([{:keys [reference]} leaf?]
-   (when (seq reference)
-     (str (if leaf? "  *" "*")
-          " Reference: "
-          (if (vector? reference)
-            (str/join ", " reference)
-            reference)
-          "\n"))))
+   (when (and (seq reference)
+              (not (#{"#"} reference)))
+     (str/replace (str (if leaf? "  *" ">")
+                       " Reference: "
+                       (if (vector? reference)
+                         (str/join ", " reference)
+                         reference)
+                       "\n\n")
+                  "] ("
+                  "]("))))
 
 (defn ->equals [{:keys [values]} loc]
   (when (and (= 1 (count values))

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -161,13 +161,14 @@
    (ready-for-table (or (:description (z/node entry)) " "))
 
    ;; required? field
-   (when (:required? (z/node entry))
-     "&#10003;")])
+   (if (:required? (z/node entry))
+     "**Required**"
+     "_Optional_")])
 
 (defn sort-entry-vecs [rows]
   (sort (fn [r1 r2]
           ;; required first
-          (let [req (compare (last r2) (last r1))]
+          (let [req (- (compare (last r2) (last r1)))]
             (if (= 0 req)
               (compare (first r1) (first r2))
               req)))
@@ -214,7 +215,6 @@
                     (sort-entry-vecs row-vs)))
      "\n\n")))
 
-
 (extend-protocol MarkdownNode
   MapType
   (->markdown-part [{:keys [anchor] :as this} loc]
@@ -249,8 +249,8 @@
          (->entry-header this loc)
          (->description this)
          (if required?
-           "* This entry is required"
-           "* This entry is optional") "\n"
+           "* This entry is **required**"
+           "* This entry is _optional_") "\n"
          (when (some-> loc z/down z/rightmost z/node fp/sequence-of?)
            "* This entry's type is sequential (allows zero or more values)\n")
          (when (some-> loc z/down z/rightmost z/node fp/set-of?)

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -4,25 +4,53 @@
             [flanders.markdown :as f.markdown]))
 
 (deftest signature-type->markdown
-  (is (= "### Signature\n\n() => Anything\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters []))))
+  (is (= "### Signature\n\n() => Anything\n\n"
+         (-> :parameters
+             (f/sig [])
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "### Signature\n\n(Integer) => Anything\n\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters [(f/int)]))))
+  (is (= "### Signature\n\n(Integer) => Anything\n\n"
+         (-> :parameters
+             (f/sig [(f/int)])
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "### Signature\n\n(Integer, String) => Anything\n\n\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str)]))))
+  (is (= "### Signature\n\n(Integer, String) => Anything\n\n"
+         (-> :parameters
+             (f/sig [(f/int) (f/str)])
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "### Signature\n\n(Integer, String, Integer, String) => Anything\n\n\n\n\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters [(f/int) (f/str) (f/int) (f/str)]))))
+  (is (= "### Signature\n\n(Integer, String, Integer, String) => Anything\n\n"
+         (-> :parameters
+             (f/sig [(f/int) (f/str) (f/int) (f/str)])
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
+  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n"
+         (-> :parameters
+             (f/sig [(f/int)] :rest-parameter (f/str))
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n\n\n\n"
-         (f.markdown/->markdown (f/sig :parameters [(f/int)] :rest-parameter (f/str)))))
+  (is (= "### Signature\n\n(Integer, String ...) => Anything\n\n"
+         (-> :parameters
+             (f/sig [(f/int)] :rest-parameter (f/str))
+             f.markdown/->markdown
+             first
+             second)))
 
-  (is (= "# `Foo`\n\n### Description\n\nThe Foo.\n\n### Signature\n\n() => Anything\n\n\n"
-         (f.markdown/->markdown (f/sig :name "Foo"
-                                       :description "The Foo."
-                                       :parameters [])))))
+  (is (= "# `Foo`\n\n### Description\n\nThe Foo.\n\n### Signature\n\n() => Anything\n\n"
+         (-> :name
+             (f/sig "Foo"
+                    :description "The Foo."
+                    :parameters [])
+             f.markdown/->markdown
+             first
+             second))))


### PR DESCRIPTION
> Related https://github.com/threatgrid/ctim/issues/321

Commit summary:

####  Cleanup CI setup

#### `markdown`: emit content for interlinked files instead of content for a single file

Now, there will be one emitted .md file per "model" (MapType).
In turn, these .md files are interlinked, making the rendered documents much shorter.
This also allows to elide most property renderings since they are now redundant.

#### Use `pr-str` and backticks to render code-related bits

####  Handle some edge cases while rendering references

* Don't render links that are simply `#`
* Render `[]()` instead of, occasionally, `[] ()`
  * the extra space would break link renderings

#### Refine header rendering
  * Add one extra `#`, making headers smaller
  *  Add backticks to denote schemas

#### Improve `required`/`optional` rendering

Before, optional fields would be rendered as nothing.
An explicit `"Optional"` text can be understood better for large tables.

#### Render the references earlier

Rendering the reference before the TOC is clearer.

#### Clarify some texts

* FooStringString -> FooString
* Inst (Date) -> DateTime
* Remove redundant `Object` text, now that references are interlinked

#### Only render references to other models within the context of an EitherType

When rendering a property, if the property of type Foo, then rendering Foo in detail is redundant because Foo is already linked to.

But if the given property is of type Either[Foo Bar Baz ..], then it is not redundant to render Foo, Bar, Baz.
