### PR TITLE
Improve `:default` swagger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
   schedule:
     # 12:00AM on the first of every month
     - cron: "0 0 1 * *"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.0.1-SNAPSHOT
+
+- populate `:default` for all schemas and use it for Swagger's `:example` field
+
 # 1.0.0 - 19th December 2023
 
 - add support for malli via `flanders.malli/->malli`

--- a/project.clj
+++ b/project.clj
@@ -8,9 +8,9 @@
                  [org.clojure/core.match "1.0.0"]
                  [cheshire "5.9.0"]
 
-                 [prismatic/schema "1.1.12"]
-                 [metosin/ring-swagger "0.26.2"]
-                 [metosin/schema-tools "0.12.2"]]
+                 [prismatic/schema "1.2.0"]
+                 [metosin/ring-swagger "1.0.0"]
+                 [metosin/schema-tools "0.12.3"]]
   :global-vars {*warn-on-reflection* true}
   :release-tasks [["clean"]
                   ["vcs" "assert-committed"]

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject threatgrid/flanders "1.0.1-iroh-8946-SNAPSHOT"
+(defproject threatgrid/flanders "1.0.1-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.11.1"]
+  :dependencies [[org.clojure/clojure "1.11.3"]
                  [org.clojure/core.match "1.0.0"]
                  [cheshire "5.9.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/flanders "1.0.1-SNAPSHOT"
+(defproject threatgrid/flanders "1.0.1-iroh-8946-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -179,13 +179,12 @@
 (defn enum [values & {:keys [open?]
                       :or {open? false}
                       :as opts}]
-  (let [v (first values)
-        default (-> values sort first)]
+  (let [v (-> values sort first)]
     (cond
-      (integer? v) (ft/map->IntegerType (merge {:default default} opts {:values values :open? open?}))
-      (number? v)  (ft/map->NumberType  (merge {:default default} opts {:values values :open? open?}))
-      (keyword? v) (ft/map->KeywordType (merge {:default default} opts {:values values :open? open?}))
-      (string? v)  (ft/map->StringType  (merge {:default default} opts {:values values :open? open?})))))
+      (integer? v) (ft/map->IntegerType (merge {:default v} opts {:values values :open? open?}))
+      (number? v)  (ft/map->NumberType  (merge {:default v} opts {:values values :open? open?}))
+      (keyword? v) (ft/map->KeywordType (merge {:default v} opts {:values values :open? open?}))
+      (string? v)  (ft/map->StringType  (merge {:default v} opts {:values values :open? open?})))))
 
 (defn eq [value & {:keys [description reference comment usage name]}]
   (enum #{value}

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -179,12 +179,13 @@
 (defn enum [values & {:keys [open?]
                       :or {open? false}
                       :as opts}]
-  (let [v (first values)]
+  (let [v (first values)
+        default (-> values sort first)]
     (cond
-      (integer? v) (ft/map->IntegerType (merge opts {:values values :open? open?}))
-      (number? v)  (ft/map->NumberType  (merge opts {:values values :open? open?}))
-      (keyword? v) (ft/map->KeywordType (merge opts {:values values :open? open?}))
-      (string? v)  (ft/map->StringType  (merge opts {:values values :open? open?})))))
+      (integer? v) (ft/map->IntegerType (merge {:default default} opts {:values values :open? open?}))
+      (number? v)  (ft/map->NumberType  (merge {:default default} opts {:values values :open? open?}))
+      (keyword? v) (ft/map->KeywordType (merge {:default default} opts {:values values :open? open?}))
+      (string? v)  (ft/map->StringType  (merge {:default default} opts {:values values :open? open?})))))
 
 (defn eq [value & {:keys [description reference comment usage name]}]
   (enum #{value}

--- a/src/flanders/core.cljc
+++ b/src/flanders/core.cljc
@@ -129,35 +129,38 @@
 (defn anything [& {:as opts}]
   (ft/map->AnythingType opts))
 
-(defn bool [& {:keys [equals] :as opts}]
+(defn bool [& {:keys [equals default] :as opts}]
   (ft/map->BooleanType
    (merge opts
           {:open? (nil? equals)
-           :default (when (some? equals) equals)})))
+           :default (if (some? equals)
+                      equals
+                      (when (some? default)
+                        default))})))
 
 (defn inst [& {:as opts}]
   (ft/map->InstType opts))
 
-(defn int [& {:keys [equals] :as opts}]
+(defn int [& {:keys [equals default] :as opts}]
   (ft/map->IntegerType
    (merge opts
           {:open? (not equals)
            :values (when equals #{equals})
-           :default (when equals equals)})))
+           :default (or equals default)})))
 
-(defn num [& {:keys [equals] :as opts}]
+(defn num [& {:keys [equals default] :as opts}]
   (ft/map->NumberType
    (merge opts
           {:open? (not equals)
            :values (when equals #{equals})
-           :default (when equals equals)})))
+           :default (or equals default)})))
 
-(defn keyword [& {:keys [equals] :as opts}]
+(defn keyword [& {:keys [equals default] :as opts}]
   (ft/map->KeywordType
    (merge opts
           {:open? (not equals)
            :values (when equals #{equals})
-           :default (when equals equals)})))
+           :default (or equals default)})))
 
 (defn key [equals & {:as opts}]
   (ft/map->KeywordType
@@ -166,12 +169,12 @@
            :values #{equals}
            :default equals})))
 
-(defn str [& {:keys [equals] :as opts}]
+(defn str [& {:keys [equals default] :as opts}]
   (ft/map->StringType
    (merge opts
           {:open? (not equals)
            :values (when equals #{equals})
-           :default (when equals equals)})))
+           :default (or equals default)})))
 
 (defn enum [values & {:keys [open?]
                       :or {open? false}

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -61,7 +61,7 @@
 
   AnythingType
   (->example [_ _]
-    {:anything "anything"})
+    "anything")
 
   BooleanType
   (->example [{:keys [default] :or {default true}} _]

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -31,66 +31,82 @@
   ;; Branches
 
   EitherType
-  (->example [{:keys [choices] :as ddl} f]
-    (let [[_ example :as example?] (find ddl :default)]
-      (if example?
-        example
-        (f (first choices)))))
+  (->example [{:keys [choices default] :as ddl} f]
+    (if (some? default)
+      default
+      (f (first choices))))
 
   MapEntry
-  (->example [{:keys [key type] :as ddl} f]
-    (let [[_ example :as example?] (find ddl :default)]
-      [(f (assoc key :key? true))
-       (f (cond-> type
-            example? (assoc :default example)))]))
+  (->example [{:keys [key type default] :as ddl} f]
+    [(f (assoc key :key? true))
+     (f (cond-> type
+          (some? default) (assoc :default default)))])
 
   MapType
   (->example [{:keys [entries default]} f]
-    (or default
-        (reduce (fn [m [k v]]
-                  (assoc m k v))
-                {}
-                (map f entries))))
+    (if (some? default)
+      default
+      (reduce (fn [m [k v]]
+                (assoc m k v))
+              {}
+              (map f entries))))
 
   SequenceOfType
   (->example [{:keys [type default]} f]
-    (or default [(f type)]))
+    (if (some? default)
+      default
+      [(f type)]))
 
   SetOfType
   (->example [{:keys [type default]} f]
-    (or default #{(f type)}))
+    (if (some? default)
+      default
+      #{(f type)}))
 
   ;; Leaves
 
   AnythingType
   (->example [{:keys [default]} _]
-    (or default "anything"))
+    (if (some? default)
+      default
+      "anything"))
 
   BooleanType
-  (->example [{:keys [default] :or {default true}} _]
-    default)
+  (->example [{:keys [default]} _]
+    (if (some? default)
+      default
+      true))
 
   InstType
   (->example [{:keys [default]} _]
-    (or default
-        #?(:clj  (Date. 1451610061000)
-           :cljs (js/date. 1451610061000))))
+    (if (some? default)
+      default
+      #?(:clj  (Date. 1451610061000)
+         :cljs (js/date. 1451610061000))))
 
   IntegerType
   (->example [{:keys [default]} _]
-    (or default 10))
+    (if (some? default)
+      default
+      10))
 
   KeywordType
   (->example [{:keys [default]} _]
-    (or default :keyword))
+    (if (some? default)
+      default
+      :keyword))
 
   NumberType
   (->example [{:keys [default]} _]
-    (or default 10.0))
+    (if (some? default)
+      default
+      10.0))
 
   StringType
   (->example [{:keys [default]} _]
-    (or default "string"))
+    (if (some? default)
+      default
+      "string"))
 
   SignatureType
   (->example [{:keys [parameters rest-parameter return]} f]

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -77,28 +77,20 @@
            :cljs (js/date. 1451610061000))))
 
   IntegerType
-  (->example [{:keys [default values]} _]
-    (or default
-        (-> values sort first)
-        10))
+  (->example [{:keys [default]} _]
+    (or default 10))
 
   KeywordType
-  (->example [{:keys [default values]} _]
-    (or default
-        (-> values sort first)
-        :keyword))
+  (->example [{:keys [default]} _]
+    (or default :keyword))
 
   NumberType
-  (->example [{:keys [default values]} _]
-    (or default
-        (-> values sort first)
-        10.0))
+  (->example [{:keys [default]} _]
+    (or default 10.0))
 
   StringType
-  (->example [{:keys [default values]} _]
-    (or default
-        (-> values sort first)
-        "string"))
+  (->example [{:keys [default]} _]
+    (or default "string"))
 
   SignatureType
   (->example [{:keys [parameters rest-parameter return]} f]

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -31,13 +31,13 @@
   ;; Branches
 
   EitherType
-  (->example [{:keys [choices default] :as ddl} f]
+  (->example [{:keys [choices default]} f]
     (if (some? default)
       default
       (f (first choices))))
 
   MapEntry
-  (->example [{:keys [key type default] :as ddl} f]
+  (->example [{:keys [key type default]} f]
     [(f (assoc key :key? true))
      (f (cond-> type
           (some? default) (assoc :default default)))])

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -37,10 +37,12 @@
     (f (first choices)))
 
   MapEntry
-  (->example [{:keys [key type]} f]
-    [(f (assoc key
-               :key? true))
-     (f type)])
+  (->example [{:keys [key type] :as ddl} f]
+    (let [[_ example :as example?] (find ddl :example)]
+      [(f (assoc key
+                 :key? true))
+       (f (cond-> type
+            example? (assoc :example example)))]))
 
   MapType
   (->example [{:keys [entries]} f]
@@ -114,8 +116,7 @@
 (defn ->example-tree
   "Get a JSON example for a DDL node"
   [ddl]
-  (if-some [[_ example] (find ddl :example)]
-    (do (when (instance? MapEntry ddl)
-          (throw (ex-info "Cannot add :example to MapEntry, add to value schema instead." {:ddl ddl})))
-        example)
+  (if-some [[_ example] (when-not (instance? MapEntry ddl)
+                          (find ddl :example))]
+    example
     (->example ddl ->example-tree)))

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -77,21 +77,22 @@
     10)
 
   KeywordType
-  (->example [{:keys [key? open? values]} _]
-    (or (match [key? open? (seq values)]
-               [_    true  _         ] (first values)
-               [_    _     nil       ] :keyword
-               [true false ([k] :seq)] k
-               :else                   (first values))
+  (->example [{:keys [default values example]} _]
+    (or default
+        (-> values sort first)
         :keyword))
 
   NumberType
-  (->example [_ _]
-    10.0)
+  (->example [{:keys [default values example]} _]
+    (or default
+        (-> values sort first)
+        10.0))
 
   StringType
-  (->example [_ _]
-    "string")
+  (->example [{:keys [default values example]} _]
+    (or default
+        (-> values sort first)
+        "string"))
 
   SignatureType
   (->example [{:keys [parameters rest-parameter return]} f]
@@ -114,5 +115,7 @@
   "Get a JSON example for a DDL node"
   [ddl]
   (if-some [[_ example] (find ddl :example)]
-    example
+    (do (when (instance? MapEntry ddl)
+          (throw (ex-info "Cannot add :example to MapEntry, add to value schema instead." {:ddl ddl})))
+        example)
     (->example ddl ->example-tree)))

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -113,6 +113,6 @@
 (defn ->example-tree
   "Get a JSON example for a DDL node"
   [ddl]
-  (if-some [[_ example] (find dll :example)]
+  (if-some [[_ example] (find ddl :example)]
     example
     (->example ddl ->example-tree)))

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -113,4 +113,6 @@
 (defn ->example-tree
   "Get a JSON example for a DDL node"
   [ddl]
-  (->example ddl ->example-tree))
+  (if-some [[_ example] (find dll :example)]
+    example
+    (->example ddl ->example-tree)))

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -1,12 +1,13 @@
 (ns flanders.example
   (:require
+   #?(:clj  [clojure.core.match :refer [match]]
+      :cljs [cljs.core.match :refer-macros [match]])
    #?(:clj  [flanders.types :as ft]
       :cljs [flanders.types
              :as ft
              :refer [AnythingType BooleanType EitherType InstType IntegerType
                      KeywordType MapEntry MapType NumberType SequenceOfType
-                     SetOfType SignatureType StringType]])
-   [flanders.schema :as fs])
+                     SetOfType SignatureType StringType]]))
   #?(:clj (:import
            [flanders.types
             AnythingType
@@ -63,8 +64,8 @@
     {:anything "anything"})
 
   BooleanType
-  (->example [_ _]
-    true)
+  (->example [{:keys [default] :or {default true}} _]
+    default)
 
   InstType
   (->example [_ _]
@@ -76,11 +77,13 @@
     10)
 
   KeywordType
-  (->example [node _]
-    (let [schema (fs/->schema node)]
-      (if (keyword? schema)
-        (name schema)
-        "keyword")))
+  (->example [{:keys [key? open? values]} _]
+    (or (match [key? open? (seq values)]
+               [_    true  _         ] (first values)
+               [_    _     nil       ] :keyword
+               [true false ([k] :seq)] k
+               :else                   (first values))
+        :keyword))
 
   NumberType
   (->example [_ _]

--- a/src/flanders/example.cljc
+++ b/src/flanders/example.cljc
@@ -1,7 +1,5 @@
 (ns flanders.example
   (:require
-   #?(:clj  [clojure.core.match :refer [match]]
-      :cljs [cljs.core.match :refer-macros [match]])
    #?(:clj  [flanders.types :as ft]
       :cljs [flanders.types
              :as ft

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -65,9 +65,7 @@
     (assert (some? type) (str "Type nil for MapEntry with key " key))
     (assert (some? key) (str "Key nil for MapEntry with type " type))
     (let [description (some :description [key entry type])
-          [example example?] (some #(when-some [[_ example] (find % :example)]
-                                      [example true])
-                                   [entry type])]
+          default (first (keep :default [entry type]))]
       [((if (and (not required?)
                  (not (:open? key))
                  (seq (:values key)))
@@ -78,7 +76,7 @@
             ;; TODO ideally we would attach these to the key, but this is unreliable.
             ;; for starters, st/optional-key and any related operations clears the metadata.
             description (assoc :description description)
-            example? (assoc :example example)))]))
+            (some? default) (assoc :default default)))]))
 
   MapType
   (->schema' [{:keys [entries] :as dll} f]

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -46,8 +46,9 @@
   #?(:cljs schema
      :clj (rs/field
             schema
-            (into {:example (example/->example-tree dll)}
-                  (select-keys dll [:description])))))
+            (let [{:keys [description]} dll]
+              (cond-> {:example (example/->example-tree dll)}
+                description (assoc :description description))))))
 
 (extend-protocol SchemaNode
 

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -1,4 +1,4 @@
-(ns flanders.schema
+(ns #_:clj-kondo/ignore flanders.schema
   (:refer-clojure :exclude [type key])
   (:require
    #?(:clj  [clojure.core.match :refer [match]]
@@ -42,14 +42,12 @@
 (def get-schema
   (memoize ->schema))
 
-(defn- describe [schema {:keys [description] :as dll}]
+(defn- describe [schema dll]
   #?(:cljs schema
-     :default (rs/field
-                schema
-                (cond-> {:example (if-some [[_ example] (find dll :example)]
-                                    example
-                                    (example/->example-tree dll))}
-                  description (assoc :description description)))))
+     :clj (rs/field
+            schema
+            (into {:example (example/->example-tree dll)}
+                  (select-keys dll [:description])))))
 
 (extend-protocol SchemaNode
 

--- a/src/flanders/schema.cljc
+++ b/src/flanders/schema.cljc
@@ -74,7 +74,7 @@
         (f (assoc key :key? true)))
        (f (cond-> type
             ;; TODO ideally we would attach these to the key, but this is unreliable.
-            ;; for starters, st/optional-key and any related operations clears the metadata.
+            ;; for starters, st/optional-keys and any related operations clears the metadata.
             description (assoc :description description)
             (some? default) (assoc :default default)))]))
 

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -109,7 +109,7 @@
   (is (= {:example {} :description "Description"} (->swagger (deref (f/def-entity-type Bar {:description "Description"})))))
   (is (= {:example {} :description "Description"} (->swagger (deref (f/def-entity-type Bar {:description "Description"})))))
   (is (= {:example {:start_time #inst "2016-01-01T01:01:01.000-00:00"
-                    :related_identities [{:identity "string", :confidence "string", :information_source "string", :relationship "string"}]}
+                    :related_identities [{:identity 10.0, :confidence "High", :information_source 10.0, :relationship 10.0}]}
           :description "Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified)."}
          (->swagger (deref (f/def-map-type Bar
                              [(f/entry :start_time Time
@@ -126,7 +126,7 @@
   (is (= {:example #inst "2016-01-01T01:01:01.000-00:00"
           :description "Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard."}
          (->swagger Time)))
-  (is (= {:example [{:identity "string", :confidence "string", :information_source "string", :relationship "string"}]
+  (is (= {:example [{:identity 10.0, :confidence "High", :information_source 10.0, :relationship 10.0}]
           :description "Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified)."}
          (->swagger (f/seq-of RelatedIdentity :description (str "Period of time when a cyber observation is valid. "
                                                                 "`start_time` must come before `end_time` (if specified).")

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -154,5 +154,5 @@
   (is (= {:example "anything" :description "AnYtHiNg"} (->swagger (assoc f/any :description "AnYtHiNg"))))
   (is (= {:example :keyword :description "Kw"} (->swagger (assoc f/any-keyword :description "Kw"))))
   (is (= {:example "string" :description "Str"} (->swagger (assoc f/any-str :description "Str"))))
-  (is (= {:example "default" :description "Str"} (->swagger (assoc f/any-str :description "Str" :example "default"))))
-  )
+  (is (= {:example "a" :description "Str"} (->swagger (f/enum #{"b" "c" "a"} :description "Str"))))
+  (is (= {:example "default" :description "Str"} (->swagger (assoc f/any-str :description "Str" :default "default")))))

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -129,18 +129,8 @@
                                                "`start_time` must come before `end_time` (if specified).")
                              :reference "[ValidTimeType](http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/)")))))
   (testing "Description on map entry overrides value description"
-    (is (= {:description "Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period."}
-           (-> (f/entry :start_time Time
-                        :description (str "Time of the observation. If the observation was "
-                                          "made over a period of time, than this field "
-                                          "indicates the start of that period."))
-               fs/->schema
-               first
-               meta
-               :json-schema)))
-    (is (= {:start_time {:example #inst "2016-01-01T01:01:01.000-00:00", :description "Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard.", :type "string", :format "date-time"}
-            :related_identities {:example [{:identity "https://example.com", :confidence "High", :information_source "MapEntry description for information_source", :relationship "string"}]
-                                 :type "array", :items {:$ref "#/definitions/RelatedIdentity"}}}
+    (is (= {:start_time {:example #inst "2016-01-01T01:01:01.000-00:00", :description "Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.", :type "string", :format "date-time"}
+            :related_identities {:example [{:identity "https://example.com", :confidence "High", :information_source "MapEntry description for information_source", :relationship "string"}], :description "Identifies other entity Identities related to this Identity.", :type "array", :items {:$ref "#/definitions/RelatedIdentity"}}}
            (js/properties
              (fs/->schema (deref (f/def-map-type Bar
                                    [(f/entry :start_time Time

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -131,11 +131,12 @@
                                                "`start_time` must come before `end_time` (if specified).")
                              :reference "[ValidTimeType](http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/)")))))
   (testing "Description on map entry overrides value description"
-    (is (= {:start_time {:example #inst "2016-01-01T01:01:01.000-00:00", :description "Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.", :type "string", :format "date-time"}
+    (is (= {:start_time {:example #inst "2525-01-01T01:01:01.000-00:00", :description "Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.", :type "string", :format "date-time"}
             :related_identities {:example [{:identity "https://example.com", :confidence "High", :information_source "MapEntry default for information_source", :relationship "string"}], :description "Identifies other entity Identities related to this Identity.", :type "array", :items {:$ref "#/definitions/RelatedIdentity"}}}
            (js/properties
              (fs/->schema (deref (f/def-map-type Bar
                                    [(f/entry :start_time Time
+                                             :default #inst "2525-01-01T01:01:01.000-00:00" 
                                              :description (str "Time of the observation. If the observation was "
                                                                "made over a period of time, than this field "
                                                                "indicates the start of that period."))

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -108,8 +108,10 @@
   (is (= {:example 9 :description "foo"} (->swagger (f/int :default 9 :description "foo"))))
   (is (= {:example 10 :description "outer"}
          (->swagger (f/either :description "outer"
-                              :tests [(constantly true)]
-                              :choices [(f/int :description "inner")]))))
+                              :tests [(constantly true)
+                                      (constantly true)]
+                              :choices [(f/int :description "inner")
+                                        (f/bool :equals true :description "Foo")]))))
   (is (= {:example {} :description "Description"} (->swagger (deref (f/def-entity-type Bar {:description "Description"})))))
   (is (= {:example {:start_time #inst "2016-01-01T01:01:01.000-00:00"
                     :related_identities [{:identity "https://example.com"

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -61,3 +61,11 @@
          (fs/->schema (f/bool :equals true))))
   (is (= (s/enum false)
          (fs/->schema (f/bool :equals false)))))
+
+(defn- ->swagger [dll] (:json-schema (meta (fs/->schema dll))))
+
+(deftest swagger-test
+  (is (= {:example false} (->swagger (f/bool :equals false))))
+  (is (= {:example true :description "Foo"} (->swagger (f/bool :equals true :description "Foo"))))
+  (is (= {:example 10 :description "foo"} (->swagger (f/int :description "foo"))))
+  (is (= {:example 10 :description "foo"} (->swagger (f/int :description "foo")))))

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -1,4 +1,4 @@
-(ns flanders.schema-test
+(ns #_:clj-kondo/ignore flanders.schema-test
   (:require
    [clojure.test :refer [deftest is testing]]
    [flanders.core :as f]

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -105,7 +105,7 @@
   (is (= {:example false} (->swagger (f/bool :equals false))))
   (is (= {:example true :description "Foo"} (->swagger (f/bool :equals true :description "Foo"))))
   (is (= {:example 10 :description "foo"} (->swagger (f/int :description "foo"))))
-  (is (= {:example 10 :description "foo"} (->swagger (f/int :description "foo"))))
+  (is (= {:example 9 :description "foo"} (->swagger (f/int :default 9 :description "foo"))))
   (is (= {:example 10 :description "outer"}
          (->swagger (f/either :description "outer"
                               :tests [(constantly true)]

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -134,4 +134,5 @@
   (is (= {:example "anything" :description "AnYtHiNg"} (->swagger (assoc f/any :description "AnYtHiNg"))))
   (is (= {:example :keyword :description "Kw"} (->swagger (assoc f/any-keyword :description "Kw"))))
   (is (= {:example "string" :description "Str"} (->swagger (assoc f/any-str :description "Str"))))
+  (is (= {:example "an example" :description "Str"} (->swagger (assoc f/any-str :description "Str" :example "an example"))))
   )

--- a/test/flanders/schema_test.clj
+++ b/test/flanders/schema_test.clj
@@ -72,7 +72,7 @@
                             "standard.")
           :name "ISO8601 Timestamp"))
 (def URI (f/str :description "A URI"
-                :example "https://example.com"))
+                :default "https://example.com"))
 (def high-med-low
   #{"Info"
     "Low"
@@ -94,7 +94,7 @@
              :description (str "Specifies the level of confidence in the assertion "
                                "of the relationship between the two objects."))
     (f/entry :information_source f/any-str
-             :example "MapEntry description for information_source"
+             :default "MapEntry default for information_source"
              :description (str "Specifies the source of the information about "
                                "the relationship between the two components."))
     (f/entry :relationship f/any-str)))
@@ -114,7 +114,7 @@
   (is (= {:example {:start_time #inst "2016-01-01T01:01:01.000-00:00"
                     :related_identities [{:identity "https://example.com"
                                           :confidence "High"
-                                          :information_source "MapEntry description for information_source"
+                                          :information_source "MapEntry default for information_source"
                                           :relationship "string"}]}
           :description "Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified)."}
          (->swagger (deref (f/def-map-type Bar
@@ -130,7 +130,7 @@
                              :reference "[ValidTimeType](http://stixproject.github.io/data-model/1.2/indicator/ValidTimeType/)")))))
   (testing "Description on map entry overrides value description"
     (is (= {:start_time {:example #inst "2016-01-01T01:01:01.000-00:00", :description "Time of the observation. If the observation was made over a period of time, than this field indicates the start of that period.", :type "string", :format "date-time"}
-            :related_identities {:example [{:identity "https://example.com", :confidence "High", :information_source "MapEntry description for information_source", :relationship "string"}], :description "Identifies other entity Identities related to this Identity.", :type "array", :items {:$ref "#/definitions/RelatedIdentity"}}}
+            :related_identities {:example [{:identity "https://example.com", :confidence "High", :information_source "MapEntry default for information_source", :relationship "string"}], :description "Identifies other entity Identities related to this Identity.", :type "array", :items {:$ref "#/definitions/RelatedIdentity"}}}
            (js/properties
              (fs/->schema (deref (f/def-map-type Bar
                                    [(f/entry :start_time Time
@@ -146,7 +146,7 @@
   (is (= {:example #inst "2016-01-01T01:01:01.000-00:00"
           :description "Schema definition for all date or timestamp values.  Serialized as a string, the field should follow the rules of the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) standard."}
          (->swagger Time)))
-  (is (= {:example [{:identity "https://example.com" , :confidence "High", :information_source "MapEntry description for information_source", :relationship "string"}]
+  (is (= {:example [{:identity "https://example.com" , :confidence "High", :information_source "MapEntry default for information_source", :relationship "string"}]
           :description "Period of time when a cyber observation is valid. `start_time` must come before `end_time` (if specified)."}
          (->swagger (f/seq-of RelatedIdentity :description (str "Period of time when a cyber observation is valid. "
                                                                 "`start_time` must come before `end_time` (if specified).")
@@ -154,5 +154,5 @@
   (is (= {:example "anything" :description "AnYtHiNg"} (->swagger (assoc f/any :description "AnYtHiNg"))))
   (is (= {:example :keyword :description "Kw"} (->swagger (assoc f/any-keyword :description "Kw"))))
   (is (= {:example "string" :description "Str"} (->swagger (assoc f/any-str :description "Str"))))
-  (is (= {:example "an example" :description "Str"} (->swagger (assoc f/any-str :description "Str" :example "an example"))))
+  (is (= {:example "default" :description "Str"} (->swagger (assoc f/any-str :description "Str" :example "default"))))
   )


### PR DESCRIPTION
https://github.com/advthreat/iroh/issues/8946

Always populate `:default` so it can be used for `:example` swagger. Since `:default` is a declared `defrecord` field, we need to treat `nil` as absent. This only seems to affect AnythingType which cannot default to `nil`.