### PR TITLE
Fix string escaping in markdown table

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/flanders "1.0.2-SNAPSHOT"
+(defproject threatgrid/flanders "1.0.2-replace-by-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject threatgrid/flanders "1.0.2-replace-by-SNAPSHOT"
+
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/flanders "1.0.1-SNAPSHOT"
+(defproject threatgrid/flanders "1.0.2-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
-(defproject threatgrid/flanders "1.0.2-replace-by-SNAPSHOT"
-
+(defproject threatgrid/flanders "1.0.1-SNAPSHOT"
   :description "flanders"
   :url "http://github.com/threatgrid/flanders"
   :license {:name "Eclipse Public License"

--- a/src/flanders/markdown.cljc
+++ b/src/flanders/markdown.cljc
@@ -37,8 +37,9 @@
 (defleaf ReferenceNode [text anchor jump-anchor])
 
 (defn ready-for-table [str]
-  (str/replace str #"(\n|\|)" {"\n" " "
-                               "\\|" "\\\\|"}))
+  (-> str
+      (str/replace \newline \space)
+      (str/replace "|" "\\\\|")))
 
 (defn ->default [{:keys [default values]}]
   (when (and default (> (count values) 1))

--- a/test/flanders/markdown_test.clj
+++ b/test/flanders/markdown_test.clj
@@ -1,8 +1,18 @@
 (ns flanders.markdown-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is]]
    [flanders.core :as f]
    [flanders.markdown :as md]))
+
+(deftest ready-for-table-test
+  (is (= " \\\\|" (md/ready-for-table "\n|"))))
+
+(f/def-entity-type Actor
+  {}
+  (f/optional-entries
+   (f/entry :confidence f/any
+            :description "separated\nby\nspaces within table")))
 
 (deftest signature-type->markdown
   (is (= "### Signature\n\n() => Anything\n\n\n"
@@ -26,4 +36,23 @@
   (is (= "# `Foo`\n\n### Description\n\nThe Foo.\n\n### Signature\n\n() => Anything\n\n\n"
          (md/->markdown (f/sig :name "Foo"
                                :description "The Foo."
-                               :parameters [])))))
+                               :parameters []))))
+
+  (is (= ["<a id=\"top\"></a>"
+          "# *Actor* Object"
+          ""
+          "| Property | Type | Description | Required? |"
+          "| -------- | ---- | ----------- | --------- |"
+          "|[confidence](#propertyconfidence-anything)|Anything|separated by spaces within table||"
+          ""
+          ""
+          "<a id=\"propertyconfidence-anything\"></a>"
+          "## Property confidence ∷ Anything"
+          ""
+          "separated"
+          "by"
+          "spaces within table"
+          ""
+          "* This entry is optional"]
+         (-> (md/->markdown Actor)
+             str/split-lines))))


### PR DESCRIPTION
The idea behind this function is to escape newlines and pipes in particular places, but it throws a NPE because `str/replace` is used incorrectly. There's a way to fix the replacement map by using vector keys but I wasn't comfortable using it and has already proven error-prone.