### PR TITLE
Add :spec support to SequenceOfType and SetOfType

### DIFF
--- a/src/flanders/spec.clj
+++ b/src/flanders/spec.clj
@@ -96,16 +96,26 @@
       map-kw))
 
   SequenceOfType
-  (->spec' [{:keys [type]} ns f]
+  (->spec' [{:keys [type spec]} ns f]
     (let [result-kw (keyword ns "seq-of")]
       (eval `(s/def ~result-kw ~(f type (str ns "." "seq-of"))))
-      (eval `(s/coll-of ~result-kw))))
+      (let [coll-spec (eval `(s/coll-of ~result-kw))]
+        (if spec
+          (s/and-spec-impl [`(s/coll-of ~result-kw) `~spec]
+                           [coll-spec spec]
+                           nil)
+          coll-spec))))
 
   SetOfType
-  (->spec' [{:keys [type]} ns f]
+  (->spec' [{:keys [type spec]} ns f]
     (let [result-kw (keyword ns "set-of")]
       (eval `(s/def ~result-kw ~(f type (str ns "." "set-of"))))
-      (eval `(s/coll-of ~result-kw :kind set?))))
+      (let [coll-spec (eval `(s/coll-of ~result-kw :kind set?))]
+        (if spec
+          (s/and-spec-impl [`(s/coll-of ~result-kw :kind set?) `~spec]
+                           [coll-spec spec]
+                           nil)
+          coll-spec))))
 
   SignatureType
   (->spec' [{:keys [parameters rest-parameter return]} ns f]

--- a/test/flanders/spec_test.clj
+++ b/test/flanders/spec_test.clj
@@ -114,6 +114,48 @@
        (fs/->spec (f/set-of (f/set-of f/any-str)) "test-set")
        #{#{"foo"}})))
 
+(defn max-len [n]
+  (fn [coll] (<= (count coll) n)))
+
+(deftest test-seq-of-with-spec
+  (testing "seq-of with custom spec predicate (max length)"
+    (is (s/valid?
+         (fs/->spec (f/seq-of f/any-str :spec #(<= (count %) 3))
+                    "test-seq-spec-1")
+         ["a" "b" "c"]))
+    (is ((complement s/valid?)
+         (fs/->spec (f/seq-of f/any-str :spec #(<= (count %) 3))
+                    "test-seq-spec-2")
+         ["a" "b" "c" "d"])))
+  (testing "seq-of with closure spec (e.g. from pred/max-len)"
+    (is (s/valid?
+         (fs/->spec (f/seq-of f/any-str :spec (max-len 2))
+                    "test-seq-spec-closure-1")
+         ["a" "b"]))
+    (is ((complement s/valid?)
+         (fs/->spec (f/seq-of f/any-str :spec (max-len 2))
+                    "test-seq-spec-closure-2")
+         ["a" "b" "c"])))
+  (testing "seq-of without spec still works"
+    (is (s/valid?
+         (fs/->spec (f/seq-of f/any-str) "test-seq-spec-3")
+         ["a" "b" "c" "d"]))))
+
+(deftest test-set-of-with-spec
+  (testing "set-of with custom spec predicate (max length)"
+    (is (s/valid?
+         (fs/->spec (f/set-of f/any-str :spec #(<= (count %) 2))
+                    "test-set-spec-1")
+         #{"a" "b"}))
+    (is ((complement s/valid?)
+         (fs/->spec (f/set-of f/any-str :spec #(<= (count %) 2))
+                    "test-set-spec-2")
+         #{"a" "b" "c"})))
+  (testing "set-of without spec still works"
+    (is (s/valid?
+         (fs/->spec (f/set-of f/any-str) "test-set-spec-3")
+         #{"a" "b" "c"}))))
+
 (deftest sig-spec-test
   (let [spec-key (fs/->spec (f/sig :parameters [(f/int)]) "foo")]
     (is (match (s/describe spec-key)


### PR DESCRIPTION
## Summary

Adds optional `:spec` predicate support to `SequenceOfType` and `SetOfType`, following the same pattern already used by `MapType`.

When provided, the `:spec` predicate is combined with `s/and` on the `s/coll-of` spec. This enables adding size constraints to collection fields:

```clojure
;; Limit a sequence to at most 1000 elements
(f/seq-of f/any-str :spec (pred/max-len 1000))

;; Limit a set to at most 500 elements
(f/set-of f/any-str :spec #(<= (count %) 500))
```

Backward compatible — omitting `:spec` preserves existing behavior.

## Motivation

CTIM schemas need size constraints on collection fields (see [XDR-46972](https://cisco-sbg.atlassian.net/browse/XDR-46972)).

## Changes

- `src/flanders/spec.clj`: `SequenceOfType` and `SetOfType` now destructure `:spec` and combine it via `s/and` when present
- `test/flanders/spec_test.clj`: Added `test-seq-of-with-spec` and `test-set-of-with-spec` tests

All 25 tests pass, 0 failures.

[XDR-46972]: https://cisco-sbg.atlassian.net/browse/XDR-46972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ