### PR TITLE
Harden GitHub Actions workflow (PSIRT-0328599349)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
     # 12:00AM on the first of every month
     - cron: "0 0 1 * *"
 
+# Least-privilege default token: this workflow only builds, lints and tests.
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -19,13 +23,13 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
+        uses: DeLaGuardo/setup-clojure@fa522696baadfef7de0fe810135f446221e665c2 # 3.7
         with:
           lein: 2.9.8
       - name: Cache project dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.m2/repository
@@ -51,16 +55,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           distribution: 'temurin'
           java-version: '8'
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@12.1
+        uses: DeLaGuardo/setup-clojure@0fc99a3bcdd086349bfb01a9262382fe3d37cd6d # 12.1
         with:
           clj-kondo: '2023.12.15'
 
@@ -75,9 +79,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Cache project dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.m2/repository
@@ -86,12 +90,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-clojure
       - name: Prepare java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2.5.1
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.7
+        uses: DeLaGuardo/setup-clojure@fa522696baadfef7de0fe810135f446221e665c2 # 3.7
         with:
           lein: 2.9.8
       - run: |


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/build.yml` against the GitHub Actions vulnerability classes flagged by **PSIRT-0328599349** (advisory: "GitHub Actions associated with threatgrid/flanders may contain vulnerabilities").

Two changes, both standard CI supply-chain hardening:

- **Pin all actions to full commit SHAs** (with a version comment). Mutable version tags (`@v4`, `@3.7`, ...) let a retagged or compromised upstream release execute arbitrary code in CI. The primary exposure was the third-party action `DeLaGuardo/setup-clojure`; the `actions/*` steps are pinned as well.
- **Add least-privilege token permissions** -- a top-level `permissions: contents: read` block. Previously the workflow inherited the repo/org default `GITHUB_TOKEN` scope. This job set only builds, lints and tests; it performs no writes (deploy to Clojars is a manual `lein` task, not CI-driven), so read-only is sufficient.

## Verified vulnerability classes

- **Unpinned third-party / first-party actions** -- FIXED (this PR).
- **Broad default token permissions** -- FIXED (this PR).
- `pull_request_target` checking out untrusted code -- not present.
- Script injection via `${{ github.event.* }}` in `run:` steps -- not present.
- Secrets exposed to fork PRs -- not present (no secrets referenced in CI).

## No behavior change

Each pinned SHA is the current tip of the version previously referenced:

- `actions/checkout` -> `34e1148` (v4.3.1)
- `actions/cache` -> `0057852` (v4.3.0) and `6f8efc2` (v3.5.0)
- `actions/setup-java` -> `17f84c3` (v3.14.1) and `91d3aa4` (v2.5.1)
- `DeLaGuardo/setup-clojure` -> `fa52269` (3.7) and `0fc99a3` (12.1)

## Follow-up (not in this PR)

- A `.github/dependabot.yml` with `package-ecosystem: github-actions` would keep these SHAs updated automatically.
- The deprecated `::set-output` usage (line ~47) should move to `$GITHUB_OUTPUT`; left out here to keep the diff security-scoped.

## Context

`threatgrid/flanders` is consumed by IROH as a dependency (`iroh/project.clj`: `[threatgrid/flanders "1.1.0"]`). This PR is filed as remediation for the PSIRT advisory; the CTIM library maintainers should confirm the version pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)