### PR TITLE
Harden Build workflow: drop eval, use $GITHUB_OUTPUT (PSIRT follow-up)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,10 @@ jobs:
           set -x
           case "${GITHUB_EVENT_NAME}" in
             #scheduled)
-            #  echo '::set-output name=matrix::{"jdk":["11","17","21"],"cmd":["test"]}}'
+            #  echo 'matrix={"jdk":["11","17","21"],"cmd":["test"]}' >> "$GITHUB_OUTPUT"
             # ;;
             *)
-              echo '::set-output name=matrix::{"jdk":["11","17","21"],"cmd":["test"]}}'
+              echo 'matrix={"jdk":["11","17","21"],"cmd":["test"]}' >> "$GITHUB_OUTPUT"
               ;;
           esac
   lint:
@@ -100,7 +100,7 @@ jobs:
           lein: 2.9.8
       - run: |
           set -x
-          eval 'lein do clean, compile :all, ${CMD}'
+          lein do clean, compile :all, "$CMD"
         env:
           CMD: ${{ matrix.cmd }}
   all-pr-checks:


### PR DESCRIPTION
## Summary

Follow-up to #59. Addresses the two remaining findings from the PSIRT review of `.github/workflows/build.yml` that #59 left out to keep that PR's diff scoped to action-pinning and token permissions.

- **Replace deprecated `::set-output` with `$GITHUB_OUTPUT`** (setup job, `set-matrix` step). GitHub deprecated `::set-output` citing output-injection concerns; the `$GITHUB_OUTPUT` environment file is the supported mechanism. Also fixes a stray trailing `}` in the emitted JSON (`...["test"]}}` -> `...["test"]}`).
- **Remove `eval` from the test job's run step.** `eval 'lein do clean, compile :all, ${CMD}'` re-parsed a matrix-derived variable through the shell -- an eval/command-injection anti-pattern. Passing it as a normal quoted argument (`lein do clean, compile :all, "$CMD"`) removes the eval.

## No behavior change

`matrix.cmd` is hardcoded to `test`, so both jobs run exactly as before:
- `setup` still emits the same matrix, now via `$GITHUB_OUTPUT`; consumers read `needs.setup.outputs.matrix` unchanged.
- `test` still runs `lein do clean, compile :all, test`.

## Findings addressed

- Deprecated `::set-output` -- FIXED (this PR).
- `eval` on a matrix-derived variable -- FIXED (this PR).
- Unpinned actions / broad token permissions -- already FIXED in #59.

## Deliberately not in this PR

- **Bumping action major versions** (`setup-java` v2->v4, `cache` v3->v4): a runtime-behavior change that deserves its own CI run; better handled by Dependabot. The actions are already SHA-pinned (#59), so the tag-mutation risk is already closed.
- **`pull_request` running PR code** (`bin/lint`, `project.clj`): inherent to build-on-PR, not a workflow defect. Mitigated by the read-only token added in #59; further hardening (require-approval-for-first-time-contributors) is a repo setting, not a workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)